### PR TITLE
add api/query to documentation and fixed incorrect parameter name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "editor.codeActionsOnSave": {
         "source.fixAll.eslint": true
     },
-    "eslint.validate": ["javascript"]
+    "eslint.validate": ["javascript"],
+    "[html]": {
+        "editor.rulers": [120]
+    }
 }

--- a/client/api-info.html
+++ b/client/api-info.html
@@ -166,11 +166,95 @@
                 </ul>
             </li>
             <li class="list-group-item">
+                <div>POST <code>qbreader.org/api/query</code></div>
+                <div>Parameters:</div>
+                <ul>
+                    <li>
+                        <code>questionType</code> - a <b>string</b> that either equals "tossup", "bonus", or "all".
+                        Otherwise, returns a <code>400 Bad Request</code> response.
+                    </li>
+                    <li>
+                        <code>searchType</code> - a <b>string</b> that either equals "tossup" or "bonus".
+                        Otherwise, returns a <code>400 Bad Request</code> response.
+                    </li>
+                    <li>
+                        [optional] <code>queryString</code> - a <b>string</b> that the query is searching for.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> it defaults to an empty string.</li>
+                        </ul>
+
+                    </li>
+                    <li>
+                        [optional] <code>regex</code> - a <b>boolean</b> that indicates whether <code>queryString</code>
+                        should be treated as a regular expression.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> it defaults to <code>false</code>.</li>
+                        </ul>
+                    </li>
+                    <li>
+                        [optional] <code>randomize</code> - a <b>boolean</b> that indicates whether the results should
+                        be in random order.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> it defaults to <code>false</code>.</li>
+                        </ul>
+                    </li>
+                    <li>
+                        [optional] <code>setName</code> - a <b>string</b> that is the name of the set to search in.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> then all sets are searched.</li>
+                        </ul>
+                    <li>
+                        [optional] <code>difficulties</code> - an <b>array of numbers</b> representing the valid
+                        possible difficulties.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> then all difficulties are allowed.</li>
+                            <li>Can also be a <b>string</b> or <b>number</b> if there is only 1 difficulty you want to
+                                select.</li>
+                        </ul>
+                    </li>
+                    <li>
+                        [optional] <code>categories</code> - an <b>array of strings</b> that contain the allowed
+                        categories.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> then all categories are allowed.</li>
+                            <li>Can also be a <b>string</b> if there is only 1 category.</li>
+                            <li>Take special care to ensure that the first letter of each word of the category is
+                                capitalized.</li>
+                        </ul>
+                    </li>
+                    <li>
+                        [optional] <code>subcategories</code> - an <b>array of strings</b> that contain the allowed
+                        subcategories.
+                        <ul>
+                            <li>If <b>undefined or omitted,</b> then all subcategories are allowed.</li>
+                            <li>Can also be a <b>string</b> if there is only 1 subcategory.</li>
+                            <li>Take special care to ensure that the first letter of each word of the subcategory is
+                                capitalized.</li>
+                            <li>This api endpoint does <b>not</b> check for consistency between categories and
+                                subcategories.</li>
+                            <li><i>For example, requesting the "history" and the "biology" and "chemistry" subcategories
+                                    will return no questions.</i></li>
+                        </ul>
+                    </li>
+                    <li>
+                        [optional] <code>maxQueryReturnLength</code> - a <b>number</b> that specifies the maximum number
+                        of questions to return
+                        <ul>
+                            <li>If <b>0, negative, undefined, or omitted,</b> then the default is 50.</li>
+                            <li>If <b>greater than 200,</b> the query will return no more than 200 questions.</li>
+                        </ul>
+                    </li>
+                    <li>
+                        <b>returns</b> - a <b>JSON object</b> of questions.
+                    </li>
+                </ul>
+            </li>
+            <li class="list-group-item">
                 <div>POST <code>qbreader.org/api/random-question</code></div>
                 <div>Parameters:</div>
                 <ul>
                     <li>
-                        <code>type</code> - a string that either equals "tossup" or "bonus".
+                        <code>questionType</code> - a <b>string</b> that either equals "tossup" or "bonus".
                         Otherwise, returns a <code>400 Bad Request</code> response.
                     </li>
                     <li>


### PR DESCRIPTION
Added documentation for `api/query` requests and corrected `type` to `questionType` in the documentation for `api/random-question`.
Also added a 120 character ruler for html files, because I saw that it seemed to be formatted that way.

I was very confused why my POST request wasn't going through until I looked at the code and found that the documentation `api/random-question` didn't match. Also can I get credentials to the MongoDB database to serve the website locally? I'm interested in contributing more to this project!