### PR TITLE
Hide powermarks until the answer is revealed

### DIFF
--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -131,10 +131,10 @@ socket.onmessage = function (event) {
 
     case 'update-answer':
         document.getElementById('answer').innerHTML = 'ANSWER: ' + data.answer;
-        let question = (document.getElementById('question').innerHTML);
+        question = (document.getElementById('question').innerHTML);
         if (powermarkPosition)
             question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);
-        const powerParts = question.split('(*)');
+        powerParts = question.split('(*)');
         document.getElementById('question').innerHTML = `${powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : powerParts[0]}`;
         break;
 

--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -4,6 +4,7 @@ let validCategories = [];
 let validSubcategories = [];
 
 let maxPacketNumber = 24;
+let powermarkPosition = 0;
 
 // Do not escape room name as that is how it is stored on the server.
 const ROOM_NAME = location.pathname.substring(13);
@@ -130,10 +131,18 @@ socket.onmessage = function (event) {
 
     case 'update-answer':
         document.getElementById('answer').innerHTML = 'ANSWER: ' + data.answer;
+        let question = (document.getElementById('question').innerHTML);
+        if (powermarkPosition)
+            question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);
+        const powerParts = question.split('(*)');
+        document.getElementById('question').innerHTML = `${powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : powerParts[0]}`;
         break;
 
     case 'update-question':
-        document.getElementById('question').innerHTML += data.word + ' ';
+        if (data.word === '(*)')
+            powermarkPosition = document.getElementById('question').innerHTML.length;
+        else
+            document.getElementById('question').innerHTML += data.word + ' ';
         break;
 
     case 'year-range':
@@ -351,6 +360,7 @@ const socketOnNext = (message) => {
     document.getElementById('next').classList.remove('btn-success');
     document.getElementById('next').innerHTML = 'Skip';
     document.getElementById('question').innerHTML = '';
+    powermarkPosition = 0;
     document.getElementById('answer').innerHTML = '';
     document.getElementById('buzz').innerHTML = 'Buzz';
     document.getElementById('buzz').disabled = false;
@@ -370,6 +380,7 @@ const socketOnStart = (message) => {
     logEvent(message.username, 'started the game');
 
     document.getElementById('question').innerHTML = '';
+    powermarkPosition = 0;
     document.getElementById('answer').innerHTML = '';
     document.getElementById('buzz').innerHTML = 'Buzz';
     document.getElementById('buzz').disabled = false;

--- a/client/singleplayer/tossups.js
+++ b/client/singleplayer/tossups.js
@@ -10,6 +10,7 @@ let validSubcategories;
 let currentlyBuzzing = false;
 let packetNumber = -1;
 let paused = false;
+let powermarkPosition = 0;
 
 // WARNING: 0-indexed (instead of 1-indexed, like in multiplayer)
 let questionNumber = 0;
@@ -196,6 +197,7 @@ async function next() {
     document.getElementById('set-name-info').innerHTML = setName;
 
     paused = false;
+    powermarkPosition = 0;
     readQuestion(new Date().getTime());
 }
 
@@ -224,7 +226,10 @@ function pause() {
 function readQuestion(expectedReadTime) {
     if (!currentlyBuzzing && questionTextSplit.length > 0) {
         const word = questionTextSplit.shift();
-        document.getElementById('question').innerHTML += word + ' ';
+        if (word === '(*)')
+            powermarkPosition = document.getElementById('question').innerHTML.length;
+        else
+            document.getElementById('question').innerHTML += word + ' ';
 
         // calculate time needed before reading next word
         let time = Math.log(word.length) + 1;
@@ -257,7 +262,11 @@ function reveal() {
 
 function revealQuestion() {
     document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[questionNumber].answer;
-    document.getElementById('question').innerHTML += questionTextSplit.join(' ');
+    let question = (document.getElementById('question').innerHTML);
+    if (powermarkPosition)
+        question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);
+    const powerParts = (question + questionTextSplit.join(' ')).split('(*)');
+    document.getElementById('question').innerHTML = `${powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : powerParts[0]}`;
 
     document.getElementById('buzz').disabled = true;
     document.getElementById('buzz').innerHTML = 'Buzz';


### PR DESCRIPTION
Resolves #135 

If a powermark is present in a tossup, it will not appear while the question is being read to better replicate a real quiz bowl match. After the answer is shown, the powermark will appear and the power section will be bolded.

Although the original issue proposed a toggle for this feature, I don't see why someone would choose not to play under this condition, so there is no toggle.