### PR TITLE
add correct/incorrect label for multiplayer rooms

### DIFF
--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -595,33 +595,48 @@ function logGiveAnswer(username, message, isLive = false, directive = null) {
         break;
     }
 
+    let secondBadge = null;
+    if (directive === 'accept' || directive === 'reject') {
+        secondBadge = document.createElement('span');
+        secondBadge.className = badge.className;  
+        secondBadge.style.marginLeft = '5px'; 
+
+        if (directive === 'accept') {
+            secondBadge.textContent = 'Correct';
+        } else if (directive === 'reject') {
+            secondBadge.textContent = 'Incorrect';
+        }
+    }
+
     const b = document.createElement('b');
     b.textContent = username;
 
     const span = document.createElement('span');
     span.textContent = message;
 
+    let li;
     if (document.getElementById('live-buzz')) {
-        const li = document.getElementById('live-buzz');
+        li = document.getElementById('live-buzz');
         li.textContent = '';
-        li.appendChild(badge);
-        li.appendChild(document.createTextNode(' '));
-        li.appendChild(b);
-        li.appendChild(document.createTextNode(' '));
-        li.appendChild(span);
     } else {
-        const li = document.createElement('li');
+        li = document.createElement('li');
         li.id = 'live-buzz';
-        li.appendChild(badge);
-        li.appendChild(document.createTextNode(' '));
-        li.appendChild(b);
-        li.appendChild(document.createTextNode(' '));
-        li.appendChild(span);
         document.getElementById('room-history').prepend(li);
     }
 
+    li.appendChild(badge);
+    li.appendChild(document.createTextNode(' '));
+    li.appendChild(b);
+    li.appendChild(document.createTextNode(' '));
+    li.appendChild(span);
+
+    if (secondBadge) {
+        li.appendChild(secondBadge);
+        li.appendChild(document.createTextNode(' '));
+    }
+
     if (!isLive) {
-        document.getElementById('live-buzz').id = '';
+        li.id = '';
     }
 }
 

--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -598,8 +598,7 @@ function logGiveAnswer(username, message, isLive = false, directive = null) {
     let secondBadge = null;
     if (directive === 'accept' || directive === 'reject') {
         secondBadge = document.createElement('span');
-        secondBadge.className = badge.className;  
-        secondBadge.style.marginLeft = '5px'; 
+        secondBadge.className = badge.className;
 
         if (directive === 'accept') {
             secondBadge.textContent = 'Correct';
@@ -631,8 +630,8 @@ function logGiveAnswer(username, message, isLive = false, directive = null) {
     li.appendChild(span);
 
     if (secondBadge) {
-        li.appendChild(secondBadge);
         li.appendChild(document.createTextNode(' '));
+        li.appendChild(secondBadge);
     }
 
     if (!isLive) {


### PR DESCRIPTION
Makes it more clear if the player got the answer right or wrong in multiplayer rooms.
Before:
![Screen Shot 2023-08-31 at 6 25 18 PM](https://github.com/qbreader/website/assets/54377451/2fdb179f-d18a-4de0-8483-5da5b8db7318)


After:
![Screen Shot 2023-08-31 at 6 21 31 PM](https://github.com/qbreader/website/assets/54377451/c9a6e192-b4b2-4d4f-a1de-72f5b5507e8c)
