### PR TITLE
make arrow icons also dropdown

### DIFF
--- a/client/database/index.js
+++ b/client/database/index.js
@@ -753,6 +753,7 @@ function QueryForm() {
     "aria-haspopup": "true"
   }, "Difficulties"), /*#__PURE__*/React.createElement("button", {
     className: "btn btn-default dropdown-toggle dropdown-toggle-split",
+    "data-bs-toggle": "dropdown",
     type: "button"
   }), /*#__PURE__*/React.createElement("ul", {
     className: "dropdown-menu checkbox-menu allow-focus",

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -800,7 +800,7 @@ function QueryForm() {
                                 type="button" aria-expanded="true" aria-haspopup="true">
                             Difficulties
                             </button>
-                            <button className="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                            <button className="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                             <ul className="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                                 <li><label><input type="checkbox" value="1" /> 1: Middle School</label></li>
                                 <li><label><input type="checkbox" value="2" /> 2: Easy High School</label></li>

--- a/client/multiplayer/room.html
+++ b/client/multiplayer/room.html
@@ -104,7 +104,8 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
+                        
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1"> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2"> 2: Easy High School</label></li>

--- a/client/singleplayer/bonuses.html
+++ b/client/singleplayer/bonuses.html
@@ -89,7 +89,7 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1"> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2"> 2: Easy High School</label></li>

--- a/client/singleplayer/tossups.html
+++ b/client/singleplayer/tossups.html
@@ -89,7 +89,7 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1"> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2"> 2: Easy High School</label></li>

--- a/client/user/stats/bonus-graph.html
+++ b/client/user/stats/bonus-graph.html
@@ -73,7 +73,7 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1" /> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2" /> 2: Easy High School</label></li>

--- a/client/user/stats/bonuses.html
+++ b/client/user/stats/bonuses.html
@@ -70,7 +70,7 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1" /> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2" /> 2: Easy High School</label></li>

--- a/client/user/stats/tossup-graph.html
+++ b/client/user/stats/tossup-graph.html
@@ -73,7 +73,7 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1" /> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2" /> 2: Easy High School</label></li>

--- a/client/user/stats/tossups.html
+++ b/client/user/stats/tossups.html
@@ -70,7 +70,7 @@
                             aria-expanded="true" aria-haspopup="true">
                             Difficulties
                         </button>
-                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" type="button"></button>
+                        <button class="btn btn-default dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" type="button"></button>
                         <ul class="dropdown-menu checkbox-menu allow-focus" id="difficulties" aria-labelledby="dropdownMenu1">
                             <li><label><input type="checkbox" value="1" /> 1: Middle School</label></li>
                             <li><label><input type="checkbox" value="2" /> 2: Easy High School</label></li>


### PR DESCRIPTION
![Screen Shot 2023-10-26 at 10 49 43 PM](https://github.com/qbreader/website/assets/54377451/d1d133b9-132c-41be-8758-838ec412eaea)
![Screen Shot 2023-10-26 at 10 49 26 PM](https://github.com/qbreader/website/assets/54377451/17e3ab3f-8fbd-4ffb-8703-8186e3230f28)

Makes it so the dropdown menus appear when the arrow portion is clicked, in addition to the "Difficulties" rectangle. Feels more intuitive.