### PR TITLE
Field regularization

### DIFF
--- a/client/admin/category-reports.js
+++ b/client/admin/category-reports.js
@@ -54,7 +54,6 @@ function TossupCard({
     const reason = tossup.reports.map(report => report.description).join('; ') || 'None given';
     document.getElementById('report-reason').value = reason;
   }
-  const powerParts = tossup.question.split('(*)');
   return /*#__PURE__*/React.createElement("div", {
     className: "card my-2"
   }, /*#__PURE__*/React.createElement("div", {
@@ -68,7 +67,7 @@ function TossupCard({
     className: "card-body"
   }, /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : tossup.question
+      __html: tossup.question
     }
   }), /*#__PURE__*/React.createElement("hr", {
     className: "my-3"

--- a/client/admin/category-reports.js
+++ b/client/admin/category-reports.js
@@ -74,7 +74,7 @@ function TossupCard({
     className: "my-3"
   }), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER:"), " ", /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: tossup?.formatted_answer
+      __html: tossup?.answer
     }
   }))), /*#__PURE__*/React.createElement("div", {
     className: "card-footer clickable",

--- a/client/admin/category-reports.js
+++ b/client/admin/category-reports.js
@@ -102,7 +102,7 @@ function BonusCard({
   }
   function getBonusPartLabel(index, defaultValue = 10, defaultDifficulty = '') {
     const value = bonus.values ? bonus.values[index] ?? defaultValue : defaultValue;
-    const difficulty = bonus.difficulties ? bonus.difficulties[index] ?? defaultDifficulty : defaultDifficulty;
+    const difficulty = bonus.difficultyModifiers ? bonus.difficultyModifiers[index] ?? defaultDifficulty : defaultDifficulty;
     return `[${value}${difficulty}]`;
   }
   function onClick() {

--- a/client/admin/category-reports.js
+++ b/client/admin/category-reports.js
@@ -127,7 +127,7 @@ function BonusCard({
     key: `${bonus._id}-${i}`
   }, /*#__PURE__*/React.createElement("hr", null), /*#__PURE__*/React.createElement("p", null, /*#__PURE__*/React.createElement("span", null, getBonusPartLabel(i), " "), /*#__PURE__*/React.createElement("span", null, bonus.parts[i])), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER: "), /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: (bonus?.formatted_answers ?? bonus.answers)[i]
+      __html: bonus?.formatted_answers[i]
     }
   }))))), /*#__PURE__*/React.createElement("div", {
     className: "card-footer clickable",

--- a/client/admin/category-reports.js
+++ b/client/admin/category-reports.js
@@ -127,7 +127,7 @@ function BonusCard({
     key: `${bonus._id}-${i}`
   }, /*#__PURE__*/React.createElement("hr", null), /*#__PURE__*/React.createElement("p", null, /*#__PURE__*/React.createElement("span", null, getBonusPartLabel(i), " "), /*#__PURE__*/React.createElement("span", null, bonus.parts[i])), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER: "), /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: bonus?.formatted_answers[i]
+      __html: bonus?.answers[i]
     }
   }))))), /*#__PURE__*/React.createElement("div", {
     className: "card-footer clickable",

--- a/client/admin/category-reports.js
+++ b/client/admin/category-reports.js
@@ -74,7 +74,7 @@ function TossupCard({
     className: "my-3"
   }), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER:"), " ", /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: tossup?.formatted_answer ?? tossup.answer
+      __html: tossup?.formatted_answer
     }
   }))), /*#__PURE__*/React.createElement("div", {
     className: "card-footer clickable",

--- a/client/admin/category-reports.jsx
+++ b/client/admin/category-reports.jsx
@@ -77,7 +77,7 @@ function TossupCard({ tossup }) {
                         __html: powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : tossup.question,
                     }}></span>
                     <hr className="my-3"></hr>
-                    <div><b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: tossup?.formatted_answer }}></span></div>
+                    <div><b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: tossup?.answer }}></span></div>
                 </div>
                 <div className="card-footer clickable" onClick={onClick} id={`fix-category-${_id}`} data-bs-toggle="modal" data-bs-target="#fix-category-modal">
                     <small className="text-muted">{packetName ? 'Packet ' + packetName : <span>&nbsp;</span>}</small>

--- a/client/admin/category-reports.jsx
+++ b/client/admin/category-reports.jsx
@@ -77,9 +77,7 @@ function TossupCard({ tossup }) {
                         __html: powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : tossup.question,
                     }}></span>
                     <hr className="my-3"></hr>
-                    <div><b>ANSWER:</b> <span dangerouslySetInnerHTML={{
-                        __html: tossup?.formatted_answer ?? tossup.answer,
-                    }}></span></div>
+                    <div><b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: tossup?.formatted_answer }}></span></div>
                 </div>
                 <div className="card-footer clickable" onClick={onClick} id={`fix-category-${_id}`} data-bs-toggle="modal" data-bs-target="#fix-category-modal">
                     <small className="text-muted">{packetName ? 'Packet ' + packetName : <span>&nbsp;</span>}</small>

--- a/client/admin/category-reports.jsx
+++ b/client/admin/category-reports.jsx
@@ -103,7 +103,7 @@ function BonusCard({ bonus }) {
 
     function getBonusPartLabel(index, defaultValue = 10, defaultDifficulty = '') {
         const value = bonus.values ? (bonus.values[index] ?? defaultValue) : defaultValue;
-        const difficulty = bonus.difficulties ? (bonus.difficulties[index] ?? defaultDifficulty) : defaultDifficulty;
+        const difficulty = bonus.difficultyModifiers ? (bonus.difficultyModifiers[index] ?? defaultDifficulty) : defaultDifficulty;
         return `[${value}${difficulty}]`;
     }
 

--- a/client/admin/category-reports.jsx
+++ b/client/admin/category-reports.jsx
@@ -59,8 +59,6 @@ function TossupCard({ tossup }) {
         document.getElementById('report-reason').value = reason;
     }
 
-    const powerParts = tossup.question.split('(*)');
-
     return (
         <div className="card my-2">
             <div className="card-header d-flex justify-content-between clickable" data-bs-toggle="collapse" data-bs-target={`#question-${_id}`}>
@@ -73,9 +71,7 @@ function TossupCard({ tossup }) {
             </div>
             <div className="card-container collapse show" id={`question-${_id}`}>
                 <div className="card-body">
-                    <span dangerouslySetInnerHTML={{
-                        __html: powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : tossup.question,
-                    }}></span>
+                    <span dangerouslySetInnerHTML={{ __html: tossup.question }}></span>
                     <hr className="my-3"></hr>
                     <div><b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: tossup?.answer }}></span></div>
                 </div>

--- a/client/admin/category-reports.jsx
+++ b/client/admin/category-reports.jsx
@@ -140,7 +140,7 @@ function BonusCard({ bonus }) {
                             </p>
                             <div>
                                 <b>ANSWER: </b>
-                                <span dangerouslySetInnerHTML={{ __html: (bonus?.formatted_answers ?? bonus.answers)[i] }}></span>
+                                <span dangerouslySetInnerHTML={{ __html: bonus?.formatted_answers[i] }}></span>
                             </div>
                         </div>,
                     )}

--- a/client/admin/category-reports.jsx
+++ b/client/admin/category-reports.jsx
@@ -138,7 +138,7 @@ function BonusCard({ bonus }) {
                             </p>
                             <div>
                                 <b>ANSWER: </b>
-                                <span dangerouslySetInnerHTML={{ __html: bonus?.formatted_answers[i] }}></span>
+                                <span dangerouslySetInnerHTML={{ __html: bonus?.answers[i] }}></span>
                             </div>
                         </div>,
                     )}

--- a/client/admin/geoword/compare.js
+++ b/client/admin/geoword/compare.js
@@ -127,7 +127,7 @@ document.getElementById('form').addEventListener('submit', event => {
                         <div><b>Given answer:</b> ${escapeHTML(myBuzz.givenAnswer)}</div>
                     </div>
                     <div class="col-6">
-                        <div><b>Answer:</b> ${removeParentheses(myBuzz.formatted_answer ?? myBuzz.answer)}</div>
+                        <div><b>Answer:</b> ${removeParentheses(myBuzz.formatted_answer)}</div>
                         <div><b>Celerity:</b> ${(opponentBuzz.celerity ?? 0.0).toFixed(3)}</div>
                         <div><b>Points:</b> ${opponentBuzz.points}</div>
                         <div><b>Given answer:</b> ${escapeHTML(opponentBuzz.givenAnswer)}</div>

--- a/client/admin/geoword/compare.js
+++ b/client/admin/geoword/compare.js
@@ -127,7 +127,7 @@ document.getElementById('form').addEventListener('submit', event => {
                         <div><b>Given answer:</b> ${escapeHTML(myBuzz.givenAnswer)}</div>
                     </div>
                     <div class="col-6">
-                        <div><b>Answer:</b> ${removeParentheses(myBuzz.formatted_answer)}</div>
+                        <div><b>Answer:</b> ${removeParentheses(myBuzz.answer)}</div>
                         <div><b>Celerity:</b> ${(opponentBuzz.celerity ?? 0.0).toFixed(3)}</div>
                         <div><b>Points:</b> ${opponentBuzz.points}</div>
                         <div><b>Given answer:</b> ${escapeHTML(opponentBuzz.givenAnswer)}</div>

--- a/client/admin/geoword/protests.js
+++ b/client/admin/geoword/protests.js
@@ -15,7 +15,7 @@ fetch('/api/admin/geoword/protests?' + new URLSearchParams({ packetName, divisio
             const { questionNumber } = tossup;
             innerHTML += `<div>${tossup.questionNumber}. ${tossup.question}</div>`;
             // innerHTML += '<hr class="my-3"></hr>';
-            innerHTML += `<div>ANSWER: ${tossup.formatted_answer ?? tossup.answer}</div>`;
+            innerHTML += `<div>ANSWER: ${tossup.formatted_answer}</div>`;
             innerHTML += `<p>&lt;${tossup.category} / ${tossup.subcategory}&gt;</p>`;
 
             if (protests.filter(protest => protest.questionNumber === questionNumber).length === 0) {

--- a/client/admin/geoword/protests.js
+++ b/client/admin/geoword/protests.js
@@ -15,7 +15,7 @@ fetch('/api/admin/geoword/protests?' + new URLSearchParams({ packetName, divisio
             const { questionNumber } = tossup;
             innerHTML += `<div>${tossup.questionNumber}. ${tossup.question}</div>`;
             // innerHTML += '<hr class="my-3"></hr>';
-            innerHTML += `<div>ANSWER: ${tossup.formatted_answer}</div>`;
+            innerHTML += `<div>ANSWER: ${tossup.answer}</div>`;
             innerHTML += `<p>&lt;${tossup.category} / ${tossup.subcategory}&gt;</p>`;
 
             if (protests.filter(protest => protest.questionNumber === questionNumber).length === 0) {
@@ -55,7 +55,7 @@ fetch('/api/admin/geoword/protests?' + new URLSearchParams({ packetName, divisio
             a.addEventListener('click', () => {
                 document.getElementById('resolve-protest-id').value = a.id;
                 document.getElementById('resolve-protest-given-answer').value = document.getElementById(`given-answer-${a.id}`).textContent;
-                document.getElementById('resolve-protest-actual-answer').innerHTML = packet[parseInt(a.attributes.question.value) - 1].formatted_answer;
+                document.getElementById('resolve-protest-actual-answer').innerHTML = packet[parseInt(a.attributes.question.value) - 1].answer;
             });
         });
     });

--- a/client/admin/geoword/stats.js
+++ b/client/admin/geoword/stats.js
@@ -19,7 +19,7 @@ fetch('/api/admin/geoword/stats?' + new URLSearchParams({ packetName, division }
                     <div><b>#${stats[i].tossup.questionNumber}</b></div>
                     <div><b>Times heard:</b> ${stats[i].timesHeard}</div>
                     <div><b>Number correct:</b> ${stats[i].numberCorrect}</div>
-                    <div><b>Answer:</b> ${stats[i].tossup.formatted_answer}</div>
+                    <div><b>Answer:</b> ${stats[i].tossup.answer}</div>
                 </div>
                 <div class="col-6">
                     <div><b>Best buzz:</b> ${stats[i].bestUsername}</div>

--- a/client/api-docs/schemas.html
+++ b/client/api-docs/schemas.html
@@ -159,7 +159,7 @@
                 </li>
                 <li class="list-group-item">
                     <div>
-                        <code>formatted_answer</code><code class="text-muted">: string</code>
+                        <code>answer</code><code class="text-muted">: string</code>
                         <code class="text-muted float-end fw-semibold text-decoration-underline">optional</code>
                     </div>
                     <div>The answerline, formatted with HTML.</div>

--- a/client/api-docs/schemas.html
+++ b/client/api-docs/schemas.html
@@ -290,7 +290,7 @@
                 </li>
                 <li class="list-group-item">
                     <div>
-                        <code>formatted_answers</code><code class="text-muted">: [string, string, string]</code>
+                        <code>answers</code><code class="text-muted">: [string, string, string]</code>
                         <code class="text-muted float-end fw-semibold text-decoration-underline">optional</code>
                     </div>
                     <div>The answerlines, formatted with HTML.</div>

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -107,7 +107,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
  */
 function getBonusPartLabel(bonus, index, defaultValue = 10, defaultDifficulty = '') {
   const value = bonus.values ? bonus.values[index] ?? defaultValue : defaultValue;
-  const difficulty = bonus.difficulties ? bonus.difficulties[index] ?? defaultDifficulty : defaultDifficulty;
+  const difficulty = bonus.difficultyModifiers ? bonus.difficultyModifiers[index] ?? defaultDifficulty : defaultDifficulty;
   return `[${value}${difficulty}]`;
 }
 function getMatchIndices(clean, regex) {

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -47,7 +47,7 @@ function downloadTossupsAsCSV(tossups, filename = 'tossups.csv') {
   hiddenElement.click();
 }
 function downloadBonusesAsCSV(bonuses, filename = 'bonuses.csv') {
-  const header = ['_id', 'set.name', 'packet.number', 'number', 'leadin', 'parts.0', 'parts.1', 'parts.2', 'answers_sanitized.0', 'answers_sanitized.1', 'answers_sanitized.2', 'formatted_answers.0', 'formatted_answers.1', 'formatted_answers.2', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
+  const header = ['_id', 'set.name', 'packet.number', 'number', 'leadin', 'parts.0', 'parts.1', 'parts.2', 'answers_sanitized.0', 'answers_sanitized.1', 'answers_sanitized.2', 'answers.0', 'answers.1', 'answers.2', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
   let csvdata = header.join(',') + '\n';
   for (const bonus of bonuses) {
     for (const key of header) {
@@ -219,8 +219,8 @@ function highlightBonusQuery({
       }
     }
     if (searchType === 'answer' || searchType === 'all') {
-      for (let i = 0; i < bonus.formatted_answers.length; i++) {
-        bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.answers_sanitized[i], word);
+      for (let i = 0; i < bonus.answers.length; i++) {
+        bonus.answers[i] = insertMatches(bonus.answers[i], bonus.answers_sanitized[i], word);
       }
     }
   }
@@ -492,7 +492,7 @@ function BonusCard({
     }
   })), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER: "), /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: hideAnswerlines ? '' : highlightedBonus?.formatted_answers[i]
+      __html: hideAnswerlines ? '' : highlightedBonus?.answers[i]
     }
   }))))), /*#__PURE__*/React.createElement("div", {
     className: `card-footer clickable ${!showCardFooter && 'd-none'}`,

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -22,7 +22,7 @@ function escapeCSVString(string) {
   return `"${string.replace(/"/g, '""').replace(/\n/g, '\\n')}"`;
 }
 function downloadTossupsAsCSV(tossups, filename = 'tossups.csv') {
-  const header = ['_id', 'set.name', 'packet.number', 'number', 'question', 'answer', 'formatted_answer', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
+  const header = ['_id', 'set.name', 'packet.number', 'number', 'question', 'answer', 'answer', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
   let csvdata = header.join(',') + '\n';
   for (const tossup of tossups) {
     for (const key of header) {
@@ -198,7 +198,7 @@ function highlightTossupQuery({
       tossup.question = insertMatches(tossup.question, tossup.unformatted_question, word);
     }
     if (searchType === 'answer' || searchType === 'all') {
-      tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.answer_sanitized, word);
+      tossup.answer = insertMatches(tossup.answer, tossup.answer_sanitized, word);
     }
   }
   return tossup;
@@ -344,7 +344,7 @@ function TossupCard({
     className: "my-3"
   }), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER:"), " ", /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: hideAnswerline ? '' : highlightedTossup?.formatted_answer
+      __html: hideAnswerline ? '' : highlightedTossup?.answer
     }
   }))), /*#__PURE__*/React.createElement("div", {
     className: `card-footer clickable ${!showCardFooter && 'd-none'}`,

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -47,7 +47,7 @@ function downloadTossupsAsCSV(tossups, filename = 'tossups.csv') {
   hiddenElement.click();
 }
 function downloadBonusesAsCSV(bonuses, filename = 'bonuses.csv') {
-  const header = ['_id', 'set.name', 'packet.number', 'number', 'leadin', 'parts.0', 'parts.1', 'parts.2', 'answers.0', 'answers.1', 'answers.2', 'formatted_answers.0', 'formatted_answers.1', 'formatted_answers.2', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
+  const header = ['_id', 'set.name', 'packet.number', 'number', 'leadin', 'parts.0', 'parts.1', 'parts.2', 'unformatted_answers.0', 'unformatted_answers.1', 'unformatted_answers.2', 'formatted_answers.0', 'formatted_answers.1', 'formatted_answers.2', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
   let csvdata = header.join(',') + '\n';
   for (const bonus of bonuses) {
     for (const key of header) {
@@ -85,7 +85,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
     textdata += `${bonus.set.name} Packet ${bonus.packet.number}\n`;
     textdata += `${bonus.number}. ${bonus.leadin}\n`;
     for (let i = 0; i < bonus.parts.length; i++) {
-      textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.answers[i]}\n`;
+      textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.unformatted_answers[i]}\n`;
     }
     textdata += `<${bonus.category} / ${bonus.subcategory}${bonus.alternate_subcategory ? ' (' + bonus.alternate_subcategory + ')' : ''}>\n\n`;
   }
@@ -223,14 +223,8 @@ function highlightBonusQuery({
       }
     }
     if (searchType === 'answer' || searchType === 'all') {
-      if (bonus.formatted_answers) {
-        for (let i = 0; i < bonus.formatted_answers.length; i++) {
-          bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.unformatted_answers[i], word);
-        }
-      } else {
-        for (let i = 0; i < bonus.answers.length; i++) {
-          bonus.answers[i] = insertMatches(bonus.answers[i], bonus.unformatted_answers[i], word);
-        }
+      for (let i = 0; i < bonus.formatted_answers.length; i++) {
+        bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.unformatted_answers[i], word);
       }
     }
   }
@@ -391,7 +385,7 @@ function BonusCard({
     let textdata = `${bonus.leadin}\n`;
     for (let i = 0; i < bonus.parts.length; i++) {
       textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\n`;
-      textdata += `ANSWER: ${bonus.answers[i]}\n`;
+      textdata += `ANSWER: ${bonus.unformatted_answers[i]}\n`;
     }
     let tag = '';
     if (bonus.category && bonus.subcategory && bonus.category !== bonus.subcategory) {
@@ -502,7 +496,7 @@ function BonusCard({
     }
   })), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER: "), /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: hideAnswerlines ? '' : (highlightedBonus?.formatted_answers ?? highlightedBonus.answers)[i]
+      __html: hideAnswerlines ? '' : highlightedBonus?.formatted_answers[i]
     }
   }))))), /*#__PURE__*/React.createElement("div", {
     className: `card-footer clickable ${!showCardFooter && 'd-none'}`,

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -77,7 +77,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
     textdata += `${tossup.set.name} Packet ${tossup.packet.number}\n`;
     textdata += `Question ID: ${tossup._id}\n`;
     textdata += `${tossup.number}. ${tossup.question}\n`;
-    textdata += `ANSWER: ${tossup.unformatted_answer}\n`;
+    textdata += `ANSWER: ${tossup.answer_sanitized}\n`;
     textdata += `<${tossup.category} / ${tossup.subcategory}${tossup.alternate_subcategory ? ' (' + tossup.alternate_subcategory + ')' : ''}>\n\n`;
   }
   for (const bonus of bonuses) {
@@ -198,7 +198,7 @@ function highlightTossupQuery({
       tossup.question = insertMatches(tossup.question, tossup.unformatted_question, word);
     }
     if (searchType === 'answer' || searchType === 'all') {
-      tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.unformatted_answer, word);
+      tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.answer_sanitized, word);
     }
   }
   return tossup;
@@ -236,7 +236,7 @@ function TossupCard({
   const _id = tossup._id;
   const packetName = tossup.packet.name;
   function clickToCopy() {
-    let textdata = `${tossup.question}\nANSWER: ${tossup.unformatted_answer}`;
+    let textdata = `${tossup.question}\nANSWER: ${tossup.answer_sanitized}`;
     let tag = '';
     if (tossup.category && tossup.subcategory && tossup.category !== tossup.subcategory) {
       tag += `${tossup.category} / ${tossup.subcategory}`;

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -47,7 +47,7 @@ function downloadTossupsAsCSV(tossups, filename = 'tossups.csv') {
   hiddenElement.click();
 }
 function downloadBonusesAsCSV(bonuses, filename = 'bonuses.csv') {
-  const header = ['_id', 'set.name', 'packet.number', 'number', 'leadin', 'parts.0', 'parts.1', 'parts.2', 'unformatted_answers.0', 'unformatted_answers.1', 'unformatted_answers.2', 'formatted_answers.0', 'formatted_answers.1', 'formatted_answers.2', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
+  const header = ['_id', 'set.name', 'packet.number', 'number', 'leadin', 'parts.0', 'parts.1', 'parts.2', 'answers_sanitized.0', 'answers_sanitized.1', 'answers_sanitized.2', 'formatted_answers.0', 'formatted_answers.1', 'formatted_answers.2', 'category', 'subcategory', 'alternate_subcategory', 'difficulty', 'set._id', 'packet._id', 'createdAt', 'updatedAt'];
   let csvdata = header.join(',') + '\n';
   for (const bonus of bonuses) {
     for (const key of header) {
@@ -85,7 +85,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
     textdata += `${bonus.set.name} Packet ${bonus.packet.number}\n`;
     textdata += `${bonus.number}. ${bonus.leadin}\n`;
     for (let i = 0; i < bonus.parts.length; i++) {
-      textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.unformatted_answers[i]}\n`;
+      textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.answers_sanitized[i]}\n`;
     }
     textdata += `<${bonus.category} / ${bonus.subcategory}${bonus.alternate_subcategory ? ' (' + bonus.alternate_subcategory + ')' : ''}>\n\n`;
   }
@@ -220,7 +220,7 @@ function highlightBonusQuery({
     }
     if (searchType === 'answer' || searchType === 'all') {
       for (let i = 0; i < bonus.formatted_answers.length; i++) {
-        bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.unformatted_answers[i], word);
+        bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.answers_sanitized[i], word);
       }
     }
   }
@@ -381,7 +381,7 @@ function BonusCard({
     let textdata = `${bonus.leadin}\n`;
     for (let i = 0; i < bonus.parts.length; i++) {
       textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\n`;
-      textdata += `ANSWER: ${bonus.unformatted_answers[i]}\n`;
+      textdata += `ANSWER: ${bonus.answers_sanitized[i]}\n`;
     }
     let tag = '';
     if (bonus.category && bonus.subcategory && bonus.category !== bonus.subcategory) {

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -316,7 +316,6 @@ function TossupCard({
       console.error('Error:', error);
     });
   }
-  const powerParts = highlightedTossup.question.split('(*)');
   return /*#__PURE__*/React.createElement("div", {
     className: "card my-2"
   }, /*#__PURE__*/React.createElement("div", {
@@ -338,7 +337,7 @@ function TossupCard({
     }
   }, /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : highlightedTossup.question
+      __html: highlightedTossup.question
     }
   }), /*#__PURE__*/React.createElement("hr", {
     className: "my-3"

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -195,7 +195,7 @@ function highlightTossupQuery({
   const words = ignoreWordOrder ? queryString.split(' ').filter(word => word !== '').map(word => new RegExp(word, 'ig')) : [regExp];
   for (const word of words) {
     if (searchType === 'question' || searchType === 'all') {
-      tossup.question = insertMatches(tossup.question, tossup.unformatted_question, word);
+      tossup.question = insertMatches(tossup.question, tossup.question_sanitized, word);
     }
     if (searchType === 'answer' || searchType === 'all') {
       tossup.answer = insertMatches(tossup.answer, tossup.answer_sanitized, word);
@@ -213,9 +213,9 @@ function highlightBonusQuery({
   const words = ignoreWordOrder ? queryString.split(' ').filter(word => word !== '').map(word => new RegExp(word, 'ig')) : [regExp];
   for (const word of words) {
     if (searchType === 'question' || searchType === 'all') {
-      bonus.leadin = insertMatches(bonus.leadin, bonus.unformatted_leadin, word);
+      bonus.leadin = insertMatches(bonus.leadin, bonus.leadin_sanitized, word);
       for (let i = 0; i < bonus.parts.length; i++) {
-        bonus.parts[i] = insertMatches(bonus.parts[i], bonus.unformatted_parts[i], word);
+        bonus.parts[i] = insertMatches(bonus.parts[i], bonus.parts_sanitized[i], word);
       }
     }
     if (searchType === 'answer' || searchType === 'all') {

--- a/client/database/index.js
+++ b/client/database/index.js
@@ -77,7 +77,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
     textdata += `${tossup.set.name} Packet ${tossup.packet.number}\n`;
     textdata += `Question ID: ${tossup._id}\n`;
     textdata += `${tossup.number}. ${tossup.question}\n`;
-    textdata += `ANSWER: ${tossup.answer}\n`;
+    textdata += `ANSWER: ${tossup.unformatted_answer}\n`;
     textdata += `<${tossup.category} / ${tossup.subcategory}${tossup.alternate_subcategory ? ' (' + tossup.alternate_subcategory + ')' : ''}>\n\n`;
   }
   for (const bonus of bonuses) {
@@ -198,11 +198,7 @@ function highlightTossupQuery({
       tossup.question = insertMatches(tossup.question, tossup.unformatted_question, word);
     }
     if (searchType === 'answer' || searchType === 'all') {
-      if (tossup.formatted_answer) {
-        tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.unformatted_answer, word);
-      } else {
-        tossup.answer = insertMatches(tossup.answer, tossup.unformatted_answer, word);
-      }
+      tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.unformatted_answer, word);
     }
   }
   return tossup;
@@ -240,7 +236,7 @@ function TossupCard({
   const _id = tossup._id;
   const packetName = tossup.packet.name;
   function clickToCopy() {
-    let textdata = `${tossup.question}\nANSWER: ${tossup.answer}`;
+    let textdata = `${tossup.question}\nANSWER: ${tossup.unformatted_answer}`;
     let tag = '';
     if (tossup.category && tossup.subcategory && tossup.category !== tossup.subcategory) {
       tag += `${tossup.category} / ${tossup.subcategory}`;
@@ -348,7 +344,7 @@ function TossupCard({
     className: "my-3"
   }), /*#__PURE__*/React.createElement("div", null, /*#__PURE__*/React.createElement("b", null, "ANSWER:"), " ", /*#__PURE__*/React.createElement("span", {
     dangerouslySetInnerHTML: {
-      __html: hideAnswerline ? '' : highlightedTossup?.formatted_answer ?? highlightedTossup.answer
+      __html: hideAnswerline ? '' : highlightedTossup?.formatted_answer
     }
   }))), /*#__PURE__*/React.createElement("div", {
     className: `card-footer clickable ${!showCardFooter && 'd-none'}`,

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -195,7 +195,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
         textdata += `${tossup.set.name} Packet ${tossup.packet.number}\n`;
         textdata += `Question ID: ${tossup._id}\n`;
         textdata += `${tossup.number}. ${tossup.question}\n`;
-        textdata += `ANSWER: ${tossup.answer}\n`;
+        textdata += `ANSWER: ${tossup.unformatted_answer}\n`;
         textdata += `<${tossup.category} / ${tossup.subcategory}${tossup.alternate_subcategory ? ' (' + tossup.alternate_subcategory + ')' : ''}>\n\n`;
     }
 
@@ -335,11 +335,7 @@ function highlightTossupQuery({ tossup, regExp, searchType = 'all', ignoreWordOr
         }
 
         if (searchType === 'answer' || searchType === 'all') {
-            if (tossup.formatted_answer) {
-                tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.unformatted_answer, word);
-            } else {
-                tossup.answer = insertMatches(tossup.answer, tossup.unformatted_answer, word);
-            }
+            tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.unformatted_answer, word);
         }
     }
 
@@ -376,7 +372,7 @@ function TossupCard({ tossup, highlightedTossup, hideAnswerline, showCardFooter,
     const packetName = tossup.packet.name;
 
     function clickToCopy() {
-        let textdata = `${tossup.question}\nANSWER: ${tossup.answer}`;
+        let textdata = `${tossup.question}\nANSWER: ${tossup.unformatted_answer}`;
 
         let tag = '';
         if (tossup.category && tossup.subcategory && tossup.category !== tossup.subcategory) {
@@ -484,9 +480,7 @@ function TossupCard({ tossup, highlightedTossup, hideAnswerline, showCardFooter,
                     }}></span>
                     <hr className="my-3"></hr>
                     <div>
-                        <b>ANSWER:</b> <span dangerouslySetInnerHTML={{
-                            __html: hideAnswerline ? '' : (highlightedTossup?.formatted_answer ?? highlightedTossup.answer),
-                        }}></span>
+                        <b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: hideAnswerline ? '' : highlightedTossup?.formatted_answer }}></span>
                     </div>
                 </div>
                 <div className={`card-footer clickable ${!showCardFooter && 'd-none'}`} onClick={showTossupStats} data-bs-toggle="modal" data-bs-target="#tossup-stats-modal">

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -148,9 +148,9 @@ function downloadBonusesAsCSV(bonuses, filename = 'bonuses.csv') {
         'answers_sanitized.0',
         'answers_sanitized.1',
         'answers_sanitized.2',
-        'formatted_answers.0',
-        'formatted_answers.1',
-        'formatted_answers.2',
+        'answers.0',
+        'answers.1',
+        'answers.2',
         'category',
         'subcategory',
         'alternate_subcategory',
@@ -357,8 +357,8 @@ function highlightBonusQuery({ bonus, regExp, searchType = 'all', ignoreWordOrde
         }
 
         if (searchType === 'answer' || searchType === 'all') {
-            for (let i = 0; i < bonus.formatted_answers.length; i++) {
-                bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.answers_sanitized[i], word);
+            for (let i = 0; i < bonus.answers.length; i++) {
+                bonus.answers[i] = insertMatches(bonus.answers[i], bonus.answers_sanitized[i], word);
             }
         }
     }
@@ -624,7 +624,7 @@ function BonusCard({ bonus, highlightedBonus, hideAnswerlines, showCardFooter, f
                             <div>
                                 <b>ANSWER: </b>
                                 <span dangerouslySetInnerHTML={{
-                                    __html: hideAnswerlines ? '' : highlightedBonus?.formatted_answers[i],
+                                    __html: hideAnswerlines ? '' : highlightedBonus?.answers[i],
                                 }}></span>
                             </div>
                         </div>,

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -331,7 +331,7 @@ function highlightTossupQuery({ tossup, regExp, searchType = 'all', ignoreWordOr
 
     for (const word of words) {
         if (searchType === 'question' || searchType === 'all') {
-            tossup.question = insertMatches(tossup.question, tossup.unformatted_question, word);
+            tossup.question = insertMatches(tossup.question, tossup.question_sanitized, word);
         }
 
         if (searchType === 'answer' || searchType === 'all') {
@@ -350,9 +350,9 @@ function highlightBonusQuery({ bonus, regExp, searchType = 'all', ignoreWordOrde
 
     for (const word of words) {
         if (searchType === 'question' || searchType === 'all') {
-            bonus.leadin = insertMatches(bonus.leadin, bonus.unformatted_leadin, word);
+            bonus.leadin = insertMatches(bonus.leadin, bonus.leadin_sanitized, word);
             for (let i = 0; i < bonus.parts.length; i++) {
-                bonus.parts[i] = insertMatches(bonus.parts[i], bonus.unformatted_parts[i], word);
+                bonus.parts[i] = insertMatches(bonus.parts[i], bonus.parts_sanitized[i], word);
             }
         }
 

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -195,7 +195,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
         textdata += `${tossup.set.name} Packet ${tossup.packet.number}\n`;
         textdata += `Question ID: ${tossup._id}\n`;
         textdata += `${tossup.number}. ${tossup.question}\n`;
-        textdata += `ANSWER: ${tossup.unformatted_answer}\n`;
+        textdata += `ANSWER: ${tossup.answer_sanitized}\n`;
         textdata += `<${tossup.category} / ${tossup.subcategory}${tossup.alternate_subcategory ? ' (' + tossup.alternate_subcategory + ')' : ''}>\n\n`;
     }
 
@@ -335,7 +335,7 @@ function highlightTossupQuery({ tossup, regExp, searchType = 'all', ignoreWordOr
         }
 
         if (searchType === 'answer' || searchType === 'all') {
-            tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.unformatted_answer, word);
+            tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.answer_sanitized, word);
         }
     }
 
@@ -372,7 +372,7 @@ function TossupCard({ tossup, highlightedTossup, hideAnswerline, showCardFooter,
     const packetName = tossup.packet.name;
 
     function clickToCopy() {
-        let textdata = `${tossup.question}\nANSWER: ${tossup.unformatted_answer}`;
+        let textdata = `${tossup.question}\nANSWER: ${tossup.answer_sanitized}`;
 
         let tag = '';
         if (tossup.category && tossup.subcategory && tossup.category !== tossup.subcategory) {

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -97,7 +97,7 @@ function downloadTossupsAsCSV(tossups, filename = 'tossups.csv') {
         'number',
         'question',
         'answer',
-        'formatted_answer',
+        'answer',
         'category',
         'subcategory',
         'alternate_subcategory',
@@ -335,7 +335,7 @@ function highlightTossupQuery({ tossup, regExp, searchType = 'all', ignoreWordOr
         }
 
         if (searchType === 'answer' || searchType === 'all') {
-            tossup.formatted_answer = insertMatches(tossup.formatted_answer, tossup.answer_sanitized, word);
+            tossup.answer = insertMatches(tossup.answer, tossup.answer_sanitized, word);
         }
     }
 
@@ -480,7 +480,7 @@ function TossupCard({ tossup, highlightedTossup, hideAnswerline, showCardFooter,
                     }}></span>
                     <hr className="my-3"></hr>
                     <div>
-                        <b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: hideAnswerline ? '' : highlightedTossup?.formatted_answer }}></span>
+                        <b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: hideAnswerline ? '' : highlightedTossup?.answer }}></span>
                     </div>
                 </div>
                 <div className={`card-footer clickable ${!showCardFooter && 'd-none'}`} onClick={showTossupStats} data-bs-toggle="modal" data-bs-target="#tossup-stats-modal">

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -145,9 +145,9 @@ function downloadBonusesAsCSV(bonuses, filename = 'bonuses.csv') {
         'parts.0',
         'parts.1',
         'parts.2',
-        'unformatted_answers.0',
-        'unformatted_answers.1',
-        'unformatted_answers.2',
+        'answers_sanitized.0',
+        'answers_sanitized.1',
+        'answers_sanitized.2',
         'formatted_answers.0',
         'formatted_answers.1',
         'formatted_answers.2',
@@ -204,7 +204,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
         textdata += `${bonus.set.name} Packet ${bonus.packet.number}\n`;
         textdata += `${bonus.number}. ${bonus.leadin}\n`;
         for (let i = 0; i < bonus.parts.length; i++) {
-            textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.unformatted_answers[i]}\n`;
+            textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.answers_sanitized[i]}\n`;
         }
         textdata += `<${bonus.category} / ${bonus.subcategory}${bonus.alternate_subcategory ? ' (' + bonus.alternate_subcategory + ')' : ''}>\n\n`;
     }
@@ -358,7 +358,7 @@ function highlightBonusQuery({ bonus, regExp, searchType = 'all', ignoreWordOrde
 
         if (searchType === 'answer' || searchType === 'all') {
             for (let i = 0; i < bonus.formatted_answers.length; i++) {
-                bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.unformatted_answers[i], word);
+                bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.answers_sanitized[i], word);
             }
         }
     }
@@ -511,7 +511,7 @@ function BonusCard({ bonus, highlightedBonus, hideAnswerlines, showCardFooter, f
         let textdata = `${bonus.leadin}\n`;
         for (let i = 0; i < bonus.parts.length; i++) {
             textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\n`;
-            textdata += `ANSWER: ${bonus.unformatted_answers[i]}\n`;
+            textdata += `ANSWER: ${bonus.answers_sanitized[i]}\n`;
         }
 
         let tag = '';

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -461,8 +461,6 @@ function TossupCard({ tossup, highlightedTossup, hideAnswerline, showCardFooter,
             });
     }
 
-    const powerParts = highlightedTossup.question.split('(*)');
-
     return (
         <div className="card my-2">
             <div className="card-header d-flex justify-content-between">
@@ -475,9 +473,7 @@ function TossupCard({ tossup, highlightedTossup, hideAnswerline, showCardFooter,
             </div>
             <div className="card-container collapse show" id={`question-${_id}`}>
                 <div className="card-body" style={{ 'fontSize': `${fontSize}px` }}>
-                    <span dangerouslySetInnerHTML={{
-                        __html: powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : highlightedTossup.question,
-                    }}></span>
+                    <span dangerouslySetInnerHTML={{ __html: highlightedTossup.question }}></span>
                     <hr className="my-3"></hr>
                     <div>
                         <b>ANSWER:</b> <span dangerouslySetInnerHTML={{ __html: hideAnswerline ? '' : highlightedTossup?.answer }}></span>

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -145,9 +145,9 @@ function downloadBonusesAsCSV(bonuses, filename = 'bonuses.csv') {
         'parts.0',
         'parts.1',
         'parts.2',
-        'answers.0',
-        'answers.1',
-        'answers.2',
+        'unformatted_answers.0',
+        'unformatted_answers.1',
+        'unformatted_answers.2',
         'formatted_answers.0',
         'formatted_answers.1',
         'formatted_answers.2',
@@ -204,7 +204,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
         textdata += `${bonus.set.name} Packet ${bonus.packet.number}\n`;
         textdata += `${bonus.number}. ${bonus.leadin}\n`;
         for (let i = 0; i < bonus.parts.length; i++) {
-            textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.answers[i]}\n`;
+            textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\nANSWER: ${bonus.unformatted_answers[i]}\n`;
         }
         textdata += `<${bonus.category} / ${bonus.subcategory}${bonus.alternate_subcategory ? ' (' + bonus.alternate_subcategory + ')' : ''}>\n\n`;
     }
@@ -361,14 +361,8 @@ function highlightBonusQuery({ bonus, regExp, searchType = 'all', ignoreWordOrde
         }
 
         if (searchType === 'answer' || searchType === 'all') {
-            if (bonus.formatted_answers) {
-                for (let i = 0; i < bonus.formatted_answers.length; i++) {
-                    bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.unformatted_answers[i], word);
-                }
-            } else {
-                for (let i = 0; i < bonus.answers.length; i++) {
-                    bonus.answers[i] = insertMatches(bonus.answers[i], bonus.unformatted_answers[i], word);
-                }
+            for (let i = 0; i < bonus.formatted_answers.length; i++) {
+                bonus.formatted_answers[i] = insertMatches(bonus.formatted_answers[i], bonus.unformatted_answers[i], word);
             }
         }
     }
@@ -523,7 +517,7 @@ function BonusCard({ bonus, highlightedBonus, hideAnswerlines, showCardFooter, f
         let textdata = `${bonus.leadin}\n`;
         for (let i = 0; i < bonus.parts.length; i++) {
             textdata += `${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}\n`;
-            textdata += `ANSWER: ${bonus.answers[i]}\n`;
+            textdata += `ANSWER: ${bonus.unformatted_answers[i]}\n`;
         }
 
         let tag = '';
@@ -636,7 +630,7 @@ function BonusCard({ bonus, highlightedBonus, hideAnswerlines, showCardFooter, f
                             <div>
                                 <b>ANSWER: </b>
                                 <span dangerouslySetInnerHTML={{
-                                    __html: hideAnswerlines ? '' : (highlightedBonus?.formatted_answers ?? highlightedBonus.answers)[i],
+                                    __html: hideAnswerlines ? '' : highlightedBonus?.formatted_answers[i],
                                 }}></span>
                             </div>
                         </div>,

--- a/client/database/index.jsx
+++ b/client/database/index.jsx
@@ -228,7 +228,7 @@ function downloadQuestionsAsText(tossups, bonuses, filename = 'data.txt') {
  */
 function getBonusPartLabel(bonus, index, defaultValue = 10, defaultDifficulty = '') {
     const value = bonus.values ? (bonus.values[index] ?? defaultValue) : defaultValue;
-    const difficulty = bonus.difficulties ? (bonus.difficulties[index] ?? defaultDifficulty) : defaultDifficulty;
+    const difficulty = bonus.difficultyModifiers ? (bonus.difficultyModifiers[index] ?? defaultDifficulty) : defaultDifficulty;
     return `[${value}${difficulty}]`;
 }
 

--- a/client/geoword/compare.js
+++ b/client/geoword/compare.js
@@ -79,7 +79,7 @@ document.getElementById('form').addEventListener('submit', event => {
                         <div><b>Given answer:</b> ${escapeHTML(myBuzz.givenAnswer)}</div>
                     </div>
                     <div class="col-6">
-                        <div><b>Answer:</b> ${removeParentheses(myBuzz.formatted_answer ?? myBuzz.answer)}</div>
+                        <div><b>Answer:</b> ${removeParentheses(myBuzz.formatted_answer)}</div>
                         <div><b>Celerity:</b> ${(opponentBuzz.celerity ?? 0.0).toFixed(3)}</div>
                         <div><b>Points:</b> ${opponentBuzz.points}</div>
                         <div><b>Given answer:</b> ${escapeHTML(opponentBuzz.givenAnswer)}</div>

--- a/client/geoword/compare.js
+++ b/client/geoword/compare.js
@@ -79,7 +79,7 @@ document.getElementById('form').addEventListener('submit', event => {
                         <div><b>Given answer:</b> ${escapeHTML(myBuzz.givenAnswer)}</div>
                     </div>
                     <div class="col-6">
-                        <div><b>Answer:</b> ${removeParentheses(myBuzz.formatted_answer)}</div>
+                        <div><b>Answer:</b> ${removeParentheses(myBuzz.answer)}</div>
                         <div><b>Celerity:</b> ${(opponentBuzz.celerity ?? 0.0).toFixed(3)}</div>
                         <div><b>Points:</b> ${opponentBuzz.points}</div>
                         <div><b>Given answer:</b> ${escapeHTML(opponentBuzz.givenAnswer)}</div>

--- a/client/geoword/packet.js
+++ b/client/geoword/packet.js
@@ -18,7 +18,7 @@ fetch('/api/geoword/packet?' + new URLSearchParams({ packetName, division }))
 
         for (const tossup of packet) {
             innerHTML += `<div>${tossup.questionNumber}. ${tossup.question}</div>`;
-            innerHTML += `<div>ANSWER: ${tossup.formatted_answer}</div>`;
+            innerHTML += `<div>ANSWER: ${tossup.answer}</div>`;
             innerHTML += `<p>&lt;${tossup.category} / ${tossup.subcategory}&gt;</p>`;
             innerHTML += '<hr class="my-3"></hr>';
         }

--- a/client/geoword/packet.js
+++ b/client/geoword/packet.js
@@ -18,7 +18,7 @@ fetch('/api/geoword/packet?' + new URLSearchParams({ packetName, division }))
 
         for (const tossup of packet) {
             innerHTML += `<div>${tossup.questionNumber}. ${tossup.question}</div>`;
-            innerHTML += `<div>ANSWER: ${tossup.formatted_answer ?? tossup.answer}</div>`;
+            innerHTML += `<div>ANSWER: ${tossup.formatted_answer}</div>`;
             innerHTML += `<p>&lt;${tossup.category} / ${tossup.subcategory}&gt;</p>`;
             innerHTML += '<hr class="my-3"></hr>';
         }

--- a/client/geoword/stats.js
+++ b/client/geoword/stats.js
@@ -44,7 +44,7 @@ fetch('/api/geoword/stats?' + new URLSearchParams({ packetName }))
                     <div><b>Best celerity:</b> ${(leaderboard[i].bestCelerity ?? 0.0).toFixed(3)}</div>
                     <div><b>Average correct celerity:</b> ${(leaderboard[i].averageCorrectCelerity ?? 0).toFixed(3)}</div>
                     <div><b>Average points:</b> ${(leaderboard[i].averagePoints ?? 0.0).toFixed(2)}</div>
-                    <div><b>Answer:</b> ${buzzArray[i].formatted_answer}</div>
+                    <div><b>Answer:</b> ${buzzArray[i].answer}</div>
                 </div>
             </div>
             <hr>

--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -530,7 +530,7 @@ const socketOnNext = (message) => {
     }
 
     tossup.question = document.getElementById('question').innerHTML;
-    tossup.answer = document.getElementById('answer').innerHTML.replace('ANSWER: ', '');
+    tossup.formatted_answer = document.getElementById('answer').innerHTML.replace('ANSWER: ', '');
 
     createTossupCard(tossup);
 

--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -530,7 +530,7 @@ const socketOnNext = (message) => {
     }
 
     tossup.question = document.getElementById('question').innerHTML;
-    tossup.formatted_answer = document.getElementById('answer').innerHTML.replace('ANSWER: ', '');
+    tossup.answer = document.getElementById('answer').innerHTML.replace('ANSWER: ', '');
 
     createTossupCard(tossup);
 

--- a/client/multiplayer/room.js
+++ b/client/multiplayer/room.js
@@ -147,20 +147,10 @@ socket.onmessage = function (event) {
         break;
 
     case 'reveal-answer': {
+        document.getElementById('question').innerHTML = tossup.question;
         document.getElementById('answer').innerHTML = 'ANSWER: ' + data.answer;
         document.getElementById('pause').disabled = true;
         showNextButton();
-
-        question = document.getElementById('question').innerHTML;
-        if (powermarkPosition) {
-            question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);
-        }
-        const powerParts = question.split('(*)');
-        if (powerParts.length > 1) {
-            document.getElementById('question').innerHTML = `<b>${powerParts[0]}(*)</b>${powerParts[1]}`;
-        } else {
-            document.getElementById('question').textContent = question;
-        }
         break;
     }
 

--- a/client/singleplayer/bonuses.js
+++ b/client/singleplayer/bonuses.js
@@ -299,7 +299,7 @@ async function getRandomBonus({ alternateSubcategories, categories, difficulties
 
 
 async function giveAnswer(givenAnswer) {
-    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].formatted_answers[currentBonusPart], givenAnswer);
+    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].answers[currentBonusPart], givenAnswer);
 
     switch (directive) {
     case 'accept':
@@ -399,7 +399,7 @@ function revealBonusPart() {
         return;
 
     const paragraph = document.createElement('p');
-    paragraph.innerHTML = 'ANSWER: ' + questions[questionNumber - 1].formatted_answers[currentBonusPart];
+    paragraph.innerHTML = 'ANSWER: ' + questions[questionNumber - 1].answers[currentBonusPart];
     document.getElementById(`bonus-part-${currentBonusPart + 1}`).appendChild(paragraph);
     currentBonusPart++;
 

--- a/client/singleplayer/bonuses.js
+++ b/client/singleplayer/bonuses.js
@@ -299,7 +299,7 @@ async function getRandomBonus({ alternateSubcategories, categories, difficulties
 
 
 async function giveAnswer(givenAnswer) {
-    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].answers[currentBonusPart], givenAnswer);
+    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].formatted_answers[currentBonusPart], givenAnswer);
 
     switch (directive) {
     case 'accept':
@@ -326,14 +326,7 @@ async function loadRandomBonuses({ alternateSubcategories, categories, difficult
     await fetch('/api/random-bonus?' + new URLSearchParams({ alternateSubcategories, categories, difficulties, maxYear, minYear, number, subcategories, threePartBonuses }))
         .then(response => response.json())
         .then(response => response.bonuses)
-        .then(questions => {
-            for (let i = 0; i < questions.length; i++) {
-                if (Object.prototype.hasOwnProperty.call(questions[i], 'formatted_answers'))
-                    questions[i].answers = questions[i].formatted_answers;
-            }
-
-            randomQuestions = questions;
-        });
+        .then(questions => { randomQuestions = questions; });
 }
 
 
@@ -406,7 +399,7 @@ function revealBonusPart() {
         return;
 
     const paragraph = document.createElement('p');
-    paragraph.innerHTML = 'ANSWER: ' + questions[questionNumber - 1].answers[currentBonusPart];
+    paragraph.innerHTML = 'ANSWER: ' + questions[questionNumber - 1].formatted_answers[currentBonusPart];
     document.getElementById(`bonus-part-${currentBonusPart + 1}`).appendChild(paragraph);
     currentBonusPart++;
 

--- a/client/singleplayer/tossups.js
+++ b/client/singleplayer/tossups.js
@@ -196,7 +196,7 @@ async function advanceQuestion() {
         } while (!isValidCategory(questions[questionNumber - 1], query.categories, query.subcategories));
 
         if (Object.keys(questions[0]).length > 0) {
-            questionText = questions[questionNumber - 1].question;
+            questionText = questions[questionNumber - 1].question_sanitized;
             questionTextSplit = questionText.split(' ').filter(word => word !== '');
             document.getElementById('question-number-info').textContent = questionNumber;
         }
@@ -469,13 +469,8 @@ function readQuestion(expectedReadTime) {
 
 
 function revealQuestion() {
+    document.getElementById('question').innerHTML = questions[questionNumber - 1].question;
     document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[questionNumber - 1].answer;
-    let question = (document.getElementById('question').innerHTML);
-    if (powermarkPosition)
-        question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);
-
-    const powerParts = (question + questionTextSplit.join(' ')).split('(*)');
-    document.getElementById('question').innerHTML = `${powerParts.length > 1 ? '<b>' + powerParts[0] + '(*)</b>' + powerParts[1] : powerParts[0]}`;
 
     document.getElementById('buzz').disabled = true;
     document.getElementById('buzz').textContent = 'Buzz';

--- a/client/singleplayer/tossups.js
+++ b/client/singleplayer/tossups.js
@@ -301,7 +301,7 @@ async function getTossups(setName, packetNumber) {
 async function giveAnswer(givenAnswer) {
     currentlyBuzzing = false;
 
-    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].formatted_answer, givenAnswer);
+    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].answer, givenAnswer);
 
     switch (directive) {
     case 'accept':
@@ -469,7 +469,7 @@ function readQuestion(expectedReadTime) {
 
 
 function revealQuestion() {
-    document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[questionNumber - 1].formatted_answer;
+    document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[questionNumber - 1].answer;
     let question = (document.getElementById('question').innerHTML);
     if (powermarkPosition)
         question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);

--- a/client/singleplayer/tossups.js
+++ b/client/singleplayer/tossups.js
@@ -301,7 +301,7 @@ async function getTossups(setName, packetNumber) {
 async function giveAnswer(givenAnswer) {
     currentlyBuzzing = false;
 
-    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].answer, givenAnswer);
+    const { directive, directedPrompt } = await checkAnswer(questions[questionNumber - 1].formatted_answer, givenAnswer);
 
     switch (directive) {
     case 'accept':
@@ -344,14 +344,7 @@ async function loadRandomTossups({ alternateSubcategories, categories, difficult
     await fetch('/api/random-tossup?' + new URLSearchParams({ alternateSubcategories, categories, difficulties, maxYear, minYear, number, powermarkOnly, subcategories, standardOnly }))
         .then(response => response.json())
         .then(response => response.tossups)
-        .then(questions => {
-            for (let i = 0; i < questions.length; i++) {
-                if (Object.prototype.hasOwnProperty.call(questions[i], 'formatted_answer'))
-                    questions[i].answer = questions[i].formatted_answer;
-            }
-
-            randomQuestions = questions;
-        });
+        .then(questions => { randomQuestions = questions; });
 }
 
 
@@ -476,7 +469,7 @@ function readQuestion(expectedReadTime) {
 
 
 function revealQuestion() {
-    document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[questionNumber - 1].answer;
+    document.getElementById('answer').innerHTML = 'ANSWER: ' + questions[questionNumber - 1].formatted_answer;
     let question = (document.getElementById('question').innerHTML);
     if (powermarkPosition)
         question = question.slice(0, powermarkPosition) + '(*) ' + question.slice(powermarkPosition);

--- a/client/user/stars/bonuses.js
+++ b/client/user/stars/bonuses.js
@@ -11,7 +11,7 @@ fetch('/auth/stars/bonuses')
                     <p>
                         ${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}
                     </p>
-                    <div>ANSWER: ${bonus?.formatted_answers[i]}</div>
+                    <div>ANSWER: ${bonus?.answers[i]}</div>
                 `;
             }
 

--- a/client/user/stars/bonuses.js
+++ b/client/user/stars/bonuses.js
@@ -65,6 +65,6 @@ fetch('/auth/stars/bonuses')
 
 function getBonusPartLabel(bonus, index, defaultValue = 10, defaultDifficulty = '') {
     const value = bonus.values ? (bonus.values[index] ?? defaultValue) : defaultValue;
-    const difficulty = bonus.difficulties ? (bonus.difficulties[index] ?? defaultDifficulty) : defaultDifficulty;
+    const difficulty = bonus.difficultyModifiers ? (bonus.difficultyModifiers[index] ?? defaultDifficulty) : defaultDifficulty;
     return `[${value}${difficulty}]`;
 }

--- a/client/user/stars/bonuses.js
+++ b/client/user/stars/bonuses.js
@@ -11,7 +11,7 @@ fetch('/auth/stars/bonuses')
                     <p>
                         ${getBonusPartLabel(bonus, i)} ${bonus.parts[i]}
                     </p>
-                    <div>ANSWER: ${(bonus?.formatted_answers ?? bonus.answers)[i]}</div>
+                    <div>ANSWER: ${bonus?.formatted_answers[i]}</div>
                 `;
             }
 

--- a/client/user/stars/tossups.js
+++ b/client/user/stars/tossups.js
@@ -20,7 +20,7 @@ fetch('/auth/stars/tossups')
                         <div class="card-body">
                             <span>${tossup.question}</span>&nbsp;
                             <hr></hr>
-                            <div><b>ANSWER:</b> ${tossup.formatted_answer}</div>
+                            <div><b>ANSWER:</b> ${tossup.answer}</div>
                         </div>
                         <div class="card-footer">
                             <small class="text-muted">${tossup.packet.name ? 'Packet ' + tossup.packet.name : '&nbsp;'}</small>

--- a/client/user/stars/tossups.js
+++ b/client/user/stars/tossups.js
@@ -20,7 +20,7 @@ fetch('/auth/stars/tossups')
                         <div class="card-body">
                             <span>${tossup.question}</span>&nbsp;
                             <hr></hr>
-                            <div><b>ANSWER:</b> ${tossup.formatted_answer ?? tossup.answer}</div>
+                            <div><b>ANSWER:</b> ${tossup.formatted_answer}</div>
                         </div>
                         <div class="card-footer">
                             <small class="text-muted">${tossup.packet.name ? 'Packet ' + tossup.packet.name : '&nbsp;'}</small>

--- a/client/user/stats/tossups.js
+++ b/client/user/stats/tossups.js
@@ -24,7 +24,7 @@ function fetchTossupStats({ difficulties = '', setName = '', includeMultiplayer 
                             <div class="card-body">
                                 <span>${tossup.question}</span>&nbsp;
                                 <hr></hr>
-                                <div><b>ANSWER:</b> ${tossup.formatted_answer ?? tossup.answer}</div>
+                                <div><b>ANSWER:</b> ${tossup.formatted_answer}</div>
                             </div>
                             <div class="card-footer">
                                 <small class="text-muted">${tossup.packet.name ? 'Packet ' + tossup.packet.name : '&nbsp;'}</small>

--- a/client/user/stats/tossups.js
+++ b/client/user/stats/tossups.js
@@ -24,7 +24,7 @@ function fetchTossupStats({ difficulties = '', setName = '', includeMultiplayer 
                             <div class="card-body">
                                 <span>${tossup.question}</span>&nbsp;
                                 <hr></hr>
-                                <div><b>ANSWER:</b> ${tossup.formatted_answer}</div>
+                                <div><b>ANSWER:</b> ${tossup.answer}</div>
                             </div>
                             <div class="card-footer">
                                 <small class="text-muted">${tossup.packet.name ? 'Packet ' + tossup.packet.name : '&nbsp;'}</small>

--- a/client/utilities.js
+++ b/client/utilities.js
@@ -74,13 +74,13 @@ const createBonusCard = (function () {
 
         questionCounter++;
 
-        const { leadin, parts, formatted_answers, category, subcategory, alternate_subcategory, set, packet, number, _id } = bonus;
+        const { leadin, parts, answers, category, subcategory, alternate_subcategory, set, packet, number, _id } = bonus;
 
         const bonusLength = bonus.parts.length;
 
         let cardHeader = '';
         for (let i = 0; i < bonusLength; i++) {
-            cardHeader += removeParentheses(formatted_answers[i]);
+            cardHeader += removeParentheses(answers[i]);
 
             if (i !== bonusLength - 1)
                 cardHeader += ' / ';
@@ -93,7 +93,7 @@ const createBonusCard = (function () {
                 ${getBonusPartLabel(bonus, i)} ${escapeHTML(parts[i])}
                 ${i + 1 === bonusLength ? `<a class="user-select-none" href="#" id="report-question-${_id}" data-bs-toggle="modal" data-bs-target="#report-question-modal">Report Question</a>` : ''}
             </p>
-            <div>ANSWER: ${formatted_answers[i]}</div>`;
+            <div>ANSWER: ${answers[i]}</div>`;
         }
 
 

--- a/client/utilities.js
+++ b/client/utilities.js
@@ -167,7 +167,7 @@ const createTossupCard = (function () {
 
         questionCounter++;
 
-        const { question, formatted_answer, category, subcategory, alternate_subcategory, set, packet, number, _id } = tossup;
+        const { question, answer, category, subcategory, alternate_subcategory, set, packet, number, _id } = tossup;
         const powerParts = question.replace(/<\/?b>/g, '').split('(*)');
 
         // append a card containing the question to the history element

--- a/client/utilities.js
+++ b/client/utilities.js
@@ -74,13 +74,13 @@ const createBonusCard = (function () {
 
         questionCounter++;
 
-        const { leadin, parts, answers, category, subcategory, alternate_subcategory, set, packet, number, _id } = bonus;
+        const { leadin, parts, formatted_answers, category, subcategory, alternate_subcategory, set, packet, number, _id } = bonus;
 
         const bonusLength = bonus.parts.length;
 
         let cardHeader = '';
         for (let i = 0; i < bonusLength; i++) {
-            cardHeader += removeParentheses(answers[i]);
+            cardHeader += removeParentheses(formatted_answers[i]);
 
             if (i !== bonusLength - 1)
                 cardHeader += ' / ';
@@ -93,7 +93,7 @@ const createBonusCard = (function () {
                 ${getBonusPartLabel(bonus, i)} ${escapeHTML(parts[i])}
                 ${i + 1 === bonusLength ? `<a class="user-select-none" href="#" id="report-question-${_id}" data-bs-toggle="modal" data-bs-target="#report-question-modal">Report Question</a>` : ''}
             </p>
-            <div>ANSWER: ${answers[i]}</div>`;
+            <div>ANSWER: ${formatted_answers[i]}</div>`;
         }
 
 
@@ -167,7 +167,7 @@ const createTossupCard = (function () {
 
         questionCounter++;
 
-        const { question, answer, category, subcategory, alternate_subcategory, set, packet, number, _id } = tossup;
+        const { question, formatted_answer, category, subcategory, alternate_subcategory, set, packet, number, _id } = tossup;
         const powerParts = question.replace(/<\/?b>/g, '').split('(*)');
 
         // append a card containing the question to the history element

--- a/client/utilities.js
+++ b/client/utilities.js
@@ -245,7 +245,7 @@ const createTossupCard = (function () {
  */
 function getBonusPartLabel(bonus, index, defaultValue = 10, defaultDifficulty = '') {
     const value = bonus.values ? (bonus.values[index] ?? defaultValue) : defaultValue;
-    const difficulty = bonus.difficulties ? (bonus.difficulties[index] ?? defaultDifficulty) : defaultDifficulty;
+    const difficulty = bonus.difficultyModifiers ? (bonus.difficultyModifiers[index] ?? defaultDifficulty) : defaultDifficulty;
     return `[${value}${difficulty}]`;
 }
 

--- a/client/utilities.js
+++ b/client/utilities.js
@@ -168,7 +168,6 @@ const createTossupCard = (function () {
         questionCounter++;
 
         const { question, answer, category, subcategory, alternate_subcategory, set, packet, number, _id } = tossup;
-        const powerParts = question.replace(/<\/?b>/g, '').split('(*)');
 
         // append a card containing the question to the history element
         const card = document.createElement('div');
@@ -186,7 +185,7 @@ const createTossupCard = (function () {
             </div>
             <div class="card-container collapse" id="question-${questionCounter}">
                 <div class="card-body">
-                    ${powerParts.length > 1 ? '<b>' + escapeHTML(powerParts[0]) + '(*)</b>' + escapeHTML(powerParts[1]) : escapeHTML(question)}
+                    ${question}
                     <a class="user-select-none" href="#" id="report-question-${_id}" data-bs-toggle="modal" data-bs-target="#report-question-modal">Report Question</a>
                     <hr></hr>
                     <div>ANSWER: ${answer}</div>

--- a/database/geoword/get-answer.js
+++ b/database/geoword/get-answer.js
@@ -12,8 +12,7 @@ async function getAnswer(packetName, division, questionNumber) {
     if (!result) {
         return '';
     } else {
-        const { answer, formatted_answer } = result;
-        return formatted_answer ?? answer;
+        return result.answer;
     }
 }
 

--- a/database/geoword/get-buzzes.js
+++ b/database/geoword/get-buzzes.js
@@ -13,7 +13,7 @@ async function getBuzzes(packetName, division, user_id, protests=false) {
         celerity: 1,
         points: 1,
         questionNumber: 1,
-        unformatted_answer: '$tossup.unformatted_answer',
+        answer_sanitized: '$tossup.answer_sanitized',
         formatted_answer: '$tossup.formatted_answer',
         givenAnswer: 1,
         prompts: 1,

--- a/database/geoword/get-buzzes.js
+++ b/database/geoword/get-buzzes.js
@@ -13,7 +13,7 @@ async function getBuzzes(packetName, division, user_id, protests=false) {
         celerity: 1,
         points: 1,
         questionNumber: 1,
-        answer: '$tossup.answer',
+        unformatted_answer: '$tossup.unformatted_answer',
         formatted_answer: '$tossup.formatted_answer',
         givenAnswer: 1,
         prompts: 1,

--- a/database/geoword/get-buzzes.js
+++ b/database/geoword/get-buzzes.js
@@ -14,7 +14,7 @@ async function getBuzzes(packetName, division, user_id, protests=false) {
         points: 1,
         questionNumber: 1,
         answer_sanitized: '$tossup.answer_sanitized',
-        formatted_answer: '$tossup.formatted_answer',
+        answer: '$tossup.answer',
         givenAnswer: 1,
         prompts: 1,
     };

--- a/database/qbreader/get-frequency-list.js
+++ b/database/qbreader/get-frequency-list.js
@@ -58,7 +58,7 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
         { $match: { subcategory, difficulty: { $in: difficulties } } },
         { $addFields: {
             // This is a regex that matches everything before the first open parenthesis or bracket.
-            regex: { $regexFind: { input: '$unformatted_answer', regex: /^[^[(]*/ } },
+            regex: { $regexFind: { input: '$answer_sanitized', regex: /^[^[(]*/ } },
         } },
         { $addFields: {
             // This is a regex that matches everything outside of parentheses ()
@@ -69,13 +69,13 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
         } },
         { $group: { _id: '$sanitized_answer', count: { $sum: 1 } } },
         { $match: { _id: { $ne: null } } },
-        { $addFields: { unformatted_answer: '$_id' } },
-        { $sort: { unformatted_answer: 1 } },
+        { $addFields: { answer_sanitized: '$_id' } },
+        { $sort: { answer_sanitized: 1 } },
     ];
 
     const bonusAggregation = [
         { $unwind: { path: '$unformatted_answers' } },
-        { $addFields: { unformatted_answer: '$unformatted_answers' } },
+        { $addFields: { answer_sanitized: '$unformatted_answers' } },
     ].concat(tossupAggregation);
 
     switch (questionType) {
@@ -109,8 +109,8 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
     const frequencyList = mergeTwoSortedArrays(
         tossupList,
         bonusList,
-        (a) => a.unformatted_answer,
-        (a, b) => ({ unformatted_answer: a.unformatted_answer, count: a.count + b.count }),
+        (a) => a.answer_sanitized,
+        (a, b) => ({ answer_sanitized: a.answer_sanitized, count: a.count + b.count }),
     );
 
     frequencyList.sort((a, b) => b.count - a.count);

--- a/database/qbreader/get-frequency-list.js
+++ b/database/qbreader/get-frequency-list.js
@@ -74,8 +74,8 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
     ];
 
     const bonusAggregation = [
-        { $unwind: { path: '$unformatted_answers' } },
-        { $addFields: { answer_sanitized: '$unformatted_answers' } },
+        { $unwind: { path: '$answers_sanitized' } },
+        { $addFields: { answer_sanitized: '$answers_sanitized' } },
     ].concat(tossupAggregation);
 
     switch (questionType) {

--- a/database/qbreader/get-frequency-list.js
+++ b/database/qbreader/get-frequency-list.js
@@ -74,8 +74,8 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
     ];
 
     const bonusAggregation = [
-        { $unwind: { path: '$answers' } },
-        { $addFields: { answer: '$answers' } },
+        { $unwind: { path: '$unformatted_answers' } },
+        { $addFields: { answer: '$unformatted_answers' } },
     ].concat(tossupAggregation);
 
     switch (questionType) {

--- a/database/qbreader/get-frequency-list.js
+++ b/database/qbreader/get-frequency-list.js
@@ -58,7 +58,7 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
         { $match: { subcategory, difficulty: { $in: difficulties } } },
         { $addFields: {
             // This is a regex that matches everything before the first open parenthesis or bracket.
-            regex: { $regexFind: { input: '$answer', regex: /^[^[(]*/ } },
+            regex: { $regexFind: { input: '$unformatted_answer', regex: /^[^[(]*/ } },
         } },
         { $addFields: {
             // This is a regex that matches everything outside of parentheses ()
@@ -69,13 +69,13 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
         } },
         { $group: { _id: '$sanitized_answer', count: { $sum: 1 } } },
         { $match: { _id: { $ne: null } } },
-        { $addFields: { answer: '$_id' } },
-        { $sort: { answer: 1 } },
+        { $addFields: { unformatted_answer: '$_id' } },
+        { $sort: { unformatted_answer: 1 } },
     ];
 
     const bonusAggregation = [
         { $unwind: { path: '$unformatted_answers' } },
-        { $addFields: { answer: '$unformatted_answers' } },
+        { $addFields: { unformatted_answer: '$unformatted_answers' } },
     ].concat(tossupAggregation);
 
     switch (questionType) {
@@ -109,8 +109,8 @@ async function getFrequencyList(subcategory, difficulties=DIFFICULTIES, limit=50
     const frequencyList = mergeTwoSortedArrays(
         tossupList,
         bonusList,
-        (a) => a.answer,
-        (a, b) => ({ answer: a.answer, count: a.count + b.count }),
+        (a) => a.unformatted_answer,
+        (a, b) => ({ unformatted_answer: a.unformatted_answer, count: a.count + b.count }),
     );
 
     frequencyList.sort((a, b) => b.count - a.count);

--- a/database/qbreader/get-packet.js
+++ b/database/qbreader/get-packet.js
@@ -28,7 +28,7 @@ function modaqifyBonus(bonus) {
         values: bonus.values ?? bonus.parts.map(() => 10),
         leadin: bonus.leadin,
         parts: bonus.parts,
-        answers: bonus.formatted_answers.map(answer => answer.replace('<i>', '<em>').replace('</i>', '</em>')),
+        answers: bonus.answers.map(answer => answer.replace('<i>', '<em>').replace('</i>', '</em>')),
         metadata: `${bonus.category} - ${bonus.subcategory}`,
     };
 

--- a/database/qbreader/get-packet.js
+++ b/database/qbreader/get-packet.js
@@ -32,8 +32,8 @@ function modaqifyBonus(bonus) {
         metadata: `${bonus.category} - ${bonus.subcategory}`,
     };
 
-    if (bonus.difficulties) {
-        result.difficultyModifiers = bonus.difficulties;
+    if (bonus.difficultyModifiers) {
+        result.difficultyModifiers = bonus.difficultyModifiers;
     }
 
     return result;

--- a/database/qbreader/get-packet.js
+++ b/database/qbreader/get-packet.js
@@ -32,16 +32,12 @@ function modaqifyBonus(bonus) {
         values: bonus.values ?? bonus.parts.map(() => 10),
         leadin: bonus.leadin,
         parts: bonus.parts,
-        answers: bonus.answers,
+        answers: bonus.formatted_answers.map(answer => answer.replace('<i>', '<em>').replace('</i>', '</em>')),
         metadata: `${bonus.category} - ${bonus.subcategory}`,
     };
 
     if (bonus.difficulties) {
         result.difficultyModifiers = bonus.difficulties;
-    }
-
-    if (bonus.formatted_answers) {
-        result.answers = bonus.formatted_answers.map(answer => answer.replace('<i>', '<em>').replace('</i>', '</em>'));
     }
 
     return result;
@@ -55,11 +51,10 @@ function modaqifyBonus(bonus) {
  * @param {Array<String>} [options.questionTypes=['tossups', 'bonuses']] - The types of questions to retrieve.
  * If only one allowed type is specified, only that type will be searched for (increasing query speed).
  * The other type will be returned as an empty array.
- * @param {boolean} [options.replaceUnformattedAnswer=true] - Whether to replace unformatted answers.
  * @param {boolean} [options.modaq=false] - Whether to output in a result compatible with MODAQ.
  * @returns {Promise<{tossups: types.Tossup[], bonuses: types.Bonus[]}>} The retrieved packet of questions.
  */
-async function getPacket({ setName, packetNumber, questionTypes = ['tossups', 'bonuses'], replaceUnformattedAnswer = true, modaq = false }) {
+async function getPacket({ setName, packetNumber, questionTypes = ['tossups', 'bonuses'], modaq = false }) {
     if (!setName || isNaN(packetNumber) || packetNumber < 1) {
         return { 'tossups': [], 'bonuses': [] };
     }
@@ -97,18 +92,6 @@ async function getPacket({ setName, packetNumber, questionTypes = ['tossups', 'b
 
     if (questionTypes.includes('bonuses')) {
         result.bonuses = values[1];
-    }
-
-    if (replaceUnformattedAnswer && !modaq) {
-        for (const tossup of result.tossups) {
-            if (Object.prototype.hasOwnProperty.call(tossup, 'formatted_answer'))
-                tossup.answer = tossup.formatted_answer;
-        }
-
-        for (const bonus of result.bonuses) {
-            if (Object.prototype.hasOwnProperty.call(bonus, 'formatted_answers'))
-                bonus.answers = bonus.formatted_answers;
-        }
     }
 
     if (modaq) {

--- a/database/qbreader/get-packet.js
+++ b/database/qbreader/get-packet.js
@@ -11,16 +11,12 @@ import * as types from '../../types.js';
 function modaqifyTossup(tossup) {
     const result = {
         question: tossup.question,
-        answer: tossup.answer,
+        answer: tossup.formatted_answer.replace('<i>', '<em>').replace('</i>', '</em>'),
         metadata: `${tossup.category} - ${tossup.subcategory}`,
     };
 
     if (tossup?.question && tossup.question.includes('(*)')) {
         result.question = '<b>' + tossup.question.replace('(*)', '(*)</b>');
-    }
-
-    if (tossup.formatted_answer) {
-        result.answer = tossup.formatted_answer.replace('<i>', '<em>').replace('</i>', '</em>');
     }
 
     return result;

--- a/database/qbreader/get-packet.js
+++ b/database/qbreader/get-packet.js
@@ -11,7 +11,7 @@ import * as types from '../../types.js';
 function modaqifyTossup(tossup) {
     const result = {
         question: tossup.question,
-        answer: tossup.formatted_answer.replace('<i>', '<em>').replace('</i>', '</em>'),
+        answer: tossup.answer.replace('<i>', '<em>').replace('</i>', '</em>'),
         metadata: `${tossup.category} - ${tossup.subcategory}`,
     };
 

--- a/database/qbreader/get-query.js
+++ b/database/qbreader/get-query.js
@@ -178,7 +178,7 @@ async function getTossupQuery(options) {
         const orQuery = [];
 
         if (['question', 'all'].includes(searchType)) {
-            orQuery.push({ unformatted_question: { $regex: word, $options: 'i' } });
+            orQuery.push({ question_sanitized: { $regex: word, $options: 'i' } });
         }
 
         if (['answer', 'all'].includes(searchType)) {
@@ -219,8 +219,8 @@ async function getBonusQuery(options) {
         const orQuery = [];
 
         if (['question', 'all'].includes(searchType)) {
-            orQuery.push({ unformatted_leadin: { $regex: word, $options: 'i' } });
-            orQuery.push({ unformatted_parts: { $regex: word, $options: 'i' } });
+            orQuery.push({ leadin_sanitized: { $regex: word, $options: 'i' } });
+            orQuery.push({ parts_sanitized: { $regex: word, $options: 'i' } });
         }
 
         if (['answer', 'all'].includes(searchType)) {
@@ -287,7 +287,7 @@ function buildQueryAggregation({ query, difficulties, categories, subcategories,
     }
 
     if (powermarkOnly) {
-        query.unformatted_question = { $regex: '\\(\\*\\)' };
+        query.question_sanitized = { $regex: '\\(\\*\\)' };
     }
 
     const aggregation = [

--- a/database/qbreader/get-query.js
+++ b/database/qbreader/get-query.js
@@ -182,7 +182,7 @@ async function getTossupQuery(options) {
         }
 
         if (['answer', 'all'].includes(searchType)) {
-            orQuery.push({ unformatted_answer: { $regex: word, $options: 'i' } });
+            orQuery.push({ answer_sanitized: { $regex: word, $options: 'i' } });
         }
 
         andQuery.push({ $or: orQuery });

--- a/database/qbreader/get-query.js
+++ b/database/qbreader/get-query.js
@@ -224,7 +224,7 @@ async function getBonusQuery(options) {
         }
 
         if (['answer', 'all'].includes(searchType)) {
-            orQuery.push({ unformatted_answers: { $regex: word, $options: 'i' } });
+            orQuery.push({ answers_sanitized: { $regex: word, $options: 'i' } });
         }
 
         andQuery.push({ $or: orQuery });

--- a/database/qbreader/get-random-bonuses.js
+++ b/database/qbreader/get-random-bonuses.js
@@ -56,7 +56,7 @@ async function getRandomBonuses({
     if (bonusLength) {
         bonusLength = parseInt(bonusLength);
         aggregation[0].$match.parts = { $size: bonusLength };
-        aggregation[0].$match.answers = { $size: bonusLength };
+        aggregation[0].$match.unformatted_answers = { $size: bonusLength };
     }
 
     if (standardOnly) {

--- a/database/qbreader/get-random-bonuses.js
+++ b/database/qbreader/get-random-bonuses.js
@@ -56,7 +56,7 @@ async function getRandomBonuses({
     if (bonusLength) {
         bonusLength = parseInt(bonusLength);
         aggregation[0].$match.parts = { $size: bonusLength };
-        aggregation[0].$match.unformatted_answers = { $size: bonusLength };
+        aggregation[0].$match.answers_sanitized = { $size: bonusLength };
     }
 
     if (standardOnly) {

--- a/database/qbreader/get-set.js
+++ b/database/qbreader/get-set.js
@@ -12,11 +12,10 @@ import * as types from '../../types.js';
  * @param {string[]} object.categories
  * @param {string[]} object.subcategories
  * @param {'tossup' | 'bonus'} [object.questionType='tossup'] - Type of question you want to get. Default: `'tossup'`.
- * @param {boolean} object.replaceUnformattedAnswer - whether to replace the 'answer(s)' key on each question with the value corresponding to 'formatted_answer(s)' (if it exists). Default: `true`
  * @param {boolean} object.reverse - whether to reverse the order of the questions in the array. Useful for functions that pop at the end of the array, Default: `false`
  * @returns {Promise<types.Tossup[] | types.Bonus[]>}
  */
-async function getSet({ setName, packetNumbers, categories, subcategories, questionType = 'tossup', replaceUnformattedAnswer = true, reverse = false }) {
+async function getSet({ setName, packetNumbers, categories, subcategories, questionType = 'tossup', reverse = false }) {
     if (!setName) return [];
 
     if (!categories || categories.length === 0) categories = CATEGORIES;
@@ -37,27 +36,9 @@ async function getSet({ setName, packetNumbers, categories, subcategories, quest
 
     if (questionType === 'tossup') {
         const questionArray = await tossups.find(filter, options).toArray();
-
-        if (replaceUnformattedAnswer) {
-            for (let i = 0; i < questionArray.length; i++) {
-                if (questionArray[i].formatted_answer) {
-                    questionArray[i].answer = questionArray[i].formatted_answer;
-                }
-            }
-        }
-
         return questionArray || [];
     } else if (questionType === 'bonus') {
         const questionArray = await bonuses.find(filter, options).toArray();
-
-        if (replaceUnformattedAnswer) {
-            for (let i = 0; i < questionArray.length; i++) {
-                if (questionArray[i].formatted_answers) {
-                    questionArray[i].answers = questionArray[i].formatted_answers;
-                }
-            }
-        }
-
         return questionArray || [];
     }
 }

--- a/database/schemas.js
+++ b/database/schemas.js
@@ -17,11 +17,11 @@ const schemas = {
                 'description': 'The question text',
                 'type': 'string',
             },
-            'formatted_answer': {
+            'answer': {
                 'description': 'The answerline, formatted with HTML',
                 'type': 'string',
             },
-            'answer': {
+            'answer_sanitized': {
                 'description': 'The answerline, unformatted',
                 'type': 'string',
             },
@@ -87,8 +87,8 @@ const schemas = {
         'required': [
             '_id',
             'question',
-            'formatted_answer',
             'answer',
+            'answer_sanitized',
             'subcategory',
             'category',
             'packet',

--- a/database/schemas.js
+++ b/database/schemas.js
@@ -126,7 +126,7 @@ const schemas = {
                 'minItems': 3,
                 'maxItems': 3,
             },
-            'formatted_answers': {
+            'answers': {
                 'description': 'The answerlines, formatted with HTML',
                 'type': 'array',
                 'items': {
@@ -135,7 +135,7 @@ const schemas = {
                 'minItems': 3,
                 'maxItems': 3,
             },
-            'answers': {
+            'answers_sanitized': {
                 'description': 'The answerlines, unformatted',
                 'type': 'array',
                 'items': {
@@ -207,8 +207,8 @@ const schemas = {
             '_id',
             'leadin',
             'parts',
-            'formatted_answers',
             'answers',
+            'answers_sanitized',
             'subcategory',
             'category',
             'packet',

--- a/server/TossupRoom.js
+++ b/server/TossupRoom.js
@@ -474,7 +474,7 @@ class TossupRoom {
         }
 
         this.questionProgress = QuestionProgressEnum.READING;
-        this.questionSplit = this.tossup.question.split(' ').filter(word => word !== '');
+        this.questionSplit = this.tossup.question_sanitized.split(' ').filter(word => word !== '');
         return true;
     }
 

--- a/server/TossupRoom.js
+++ b/server/TossupRoom.js
@@ -166,10 +166,10 @@ class TossupRoom {
             }));
         }
 
-        if (this.questionProgress === QuestionProgressEnum.ANSWER_REVEALED && this.tossup?.answer) {
+        if (this.questionProgress === QuestionProgressEnum.ANSWER_REVEALED && this.tossup?.formatted_answer) {
             socket.send(JSON.stringify({
                 type: 'reveal-answer',
-                answer: this.tossup.answer,
+                answer: this.tossup.formatted_answer,
             }));
         }
 
@@ -473,10 +473,6 @@ class TossupRoom {
             this.tossup = this.randomQuestionCache.pop();
         }
 
-        if (Object.prototype.hasOwnProperty.call(this.tossup, 'formatted_answer')) {
-            this.tossup.answer = this.tossup.formatted_answer;
-        }
-
         this.questionProgress = QuestionProgressEnum.READING;
         this.questionSplit = this.tossup.question.split(' ').filter(word => word !== '');
         return true;
@@ -544,7 +540,7 @@ class TossupRoom {
         const celerity = this.questionSplit.slice(this.wordIndex).join(' ').length / this.tossup.question.length;
         const endOfQuestion = (this.wordIndex === this.questionSplit.length);
         const inPower = this.questionSplit.indexOf('(*)') >= this.wordIndex;
-        const { directive, directedPrompt } = checkAnswer(this.tossup.answer, givenAnswer);
+        const { directive, directedPrompt } = checkAnswer(this.tossup.formatted_answer, givenAnswer);
         const points = scoreTossup({
             isCorrect: directive === 'accept',
             inPower,
@@ -676,7 +672,7 @@ class TossupRoom {
 
         this.sendSocketMessage({
             type: 'reveal-answer',
-            answer: this.tossup.answer,
+            answer: this.tossup.formatted_answer,
         });
 
         this.wordIndex = this.questionSplit.length;

--- a/server/TossupRoom.js
+++ b/server/TossupRoom.js
@@ -166,10 +166,10 @@ class TossupRoom {
             }));
         }
 
-        if (this.questionProgress === QuestionProgressEnum.ANSWER_REVEALED && this.tossup?.formatted_answer) {
+        if (this.questionProgress === QuestionProgressEnum.ANSWER_REVEALED && this.tossup?.answer) {
             socket.send(JSON.stringify({
                 type: 'reveal-answer',
-                answer: this.tossup.formatted_answer,
+                answer: this.tossup.answer,
             }));
         }
 
@@ -540,7 +540,7 @@ class TossupRoom {
         const celerity = this.questionSplit.slice(this.wordIndex).join(' ').length / this.tossup.question.length;
         const endOfQuestion = (this.wordIndex === this.questionSplit.length);
         const inPower = this.questionSplit.indexOf('(*)') >= this.wordIndex;
-        const { directive, directedPrompt } = checkAnswer(this.tossup.formatted_answer, givenAnswer);
+        const { directive, directedPrompt } = checkAnswer(this.tossup.answer, givenAnswer);
         const points = scoreTossup({
             isCorrect: directive === 'accept',
             inPower,
@@ -672,7 +672,7 @@ class TossupRoom {
 
         this.sendSocketMessage({
             type: 'reveal-answer',
-            answer: this.tossup.formatted_answer,
+            answer: this.tossup.answer,
         });
 
         this.wordIndex = this.questionSplit.length;

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -77,7 +77,7 @@ async function testCorrectness() {
                 assert.propertyVal(tossups, 'count', tossupCount, 'tossup count');
                 assert.propertyVal(bonuses, 'count', bonusCount, 'bonus count');
                 assert.strictEqual(tossups.questionArray[0].question, expectedFirstTossupQueston, 'tossup array - question');
-                assert.strictEqual(tossups.questionArray[0].unformatted_answer, expectedFirstTossupAnswer, 'tossup array - answer');
+                assert.strictEqual(tossups.questionArray[0].answer_sanitized, expectedFirstTossupAnswer, 'tossup array - answer');
             });
         }
         {

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -77,7 +77,7 @@ async function testCorrectness() {
                 assert.propertyVal(tossups, 'count', tossupCount, 'tossup count');
                 assert.propertyVal(bonuses, 'count', bonusCount, 'bonus count');
                 assert.strictEqual(tossups.questionArray[0].question, expectedFirstTossupQueston, 'tossup array - question');
-                assert.strictEqual(tossups.questionArray[0].answer, expectedFirstTossupAnswer, 'tossup array - answer');
+                assert.strictEqual(tossups.questionArray[0].unformatted_answer, expectedFirstTossupAnswer, 'tossup array - answer');
             });
         }
         {
@@ -113,7 +113,7 @@ async function testCorrectness() {
                 assert.propertyVal(bonuses, 'length', bonusCount, 'bonus count');
                 assert.propertyVal(bonuses[0], 'leadin', expectedFirstLeadin, 'bonuses - leadins');
                 assert.strictEqual(tossups[0].question, expectedFirstTossupQueston, 'tossups - question');
-                assert.strictEqual(tossups[0].answer, expectedFirstTossupAnswer, 'tossups - answer');
+                assert.strictEqual(tossups[0].formatted_answer, expectedFirstTossupAnswer, 'tossups - answer');
             });
         }
         {
@@ -134,7 +134,7 @@ async function testCorrectness() {
                 assert.propertyVal(bonuses, 'length', bonusCount, 'bonus count');
                 assert.propertyVal(bonuses[0], 'leadin', expectedFirstLeadin, 'bonuses - leadins');
                 assert.strictEqual(tossups[0].question, expectedFirstTossupQueston, 'tossups - question');
-                assert.strictEqual(tossups[0].answer, expectedFirstTossupAnswer, 'tossups - answer');
+                assert.strictEqual(tossups[0].formatted_answer, expectedFirstTossupAnswer, 'tossups - answer');
             });
         }
 

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -113,7 +113,7 @@ async function testCorrectness() {
                 assert.propertyVal(bonuses, 'length', bonusCount, 'bonus count');
                 assert.propertyVal(bonuses[0], 'leadin', expectedFirstLeadin, 'bonuses - leadins');
                 assert.strictEqual(tossups[0].question, expectedFirstTossupQueston, 'tossups - question');
-                assert.strictEqual(tossups[0].formatted_answer, expectedFirstTossupAnswer, 'tossups - answer');
+                assert.strictEqual(tossups[0].answer, expectedFirstTossupAnswer, 'tossups - answer');
             });
         }
         {
@@ -134,7 +134,7 @@ async function testCorrectness() {
                 assert.propertyVal(bonuses, 'length', bonusCount, 'bonus count');
                 assert.propertyVal(bonuses[0], 'leadin', expectedFirstLeadin, 'bonuses - leadins');
                 assert.strictEqual(tossups[0].question, expectedFirstTossupQueston, 'tossups - question');
-                assert.strictEqual(tossups[0].formatted_answer, expectedFirstTossupAnswer, 'tossups - answer');
+                assert.strictEqual(tossups[0].answer, expectedFirstTossupAnswer, 'tossups - answer');
             });
         }
 

--- a/types.js
+++ b/types.js
@@ -39,7 +39,7 @@ import { ObjectId } from 'mongodb';
  * @typedef {object} TossupProperties
  * @property {string} question
  * @property {string} answer_sanitized
- * @property {string} formatted_answer
+ * @property {string} answer
  * @property {"tossup"} type
  *
  * @typedef {Question & TossupProperties} Tossup

--- a/types.js
+++ b/types.js
@@ -38,7 +38,7 @@ import { ObjectId } from 'mongodb';
 /**
  * @typedef {object} TossupProperties
  * @property {string} question
- * @property {string} unformatted_answer
+ * @property {string} answer_sanitized
  * @property {string} formatted_answer
  * @property {"tossup"} type
  *

--- a/types.js
+++ b/types.js
@@ -50,7 +50,7 @@ import { ObjectId } from 'mongodb';
  * @typedef {object} BonusProperties
  * @property {string} leadin
  * @property {string[]} parts
- * @property {string[]} unformatted_answers
+ * @property {string[]} answers_sanitized
  * @property {string[]} formatted_answers
  * @property {number[]} [values]
  * @property {("e" | "m" | "h")[]} [difficulties]

--- a/types.js
+++ b/types.js
@@ -53,7 +53,7 @@ import { ObjectId } from 'mongodb';
  * @property {string[]} answers_sanitized
  * @property {string[]} answers
  * @property {number[]} [values]
- * @property {("e" | "m" | "h")[]} [difficulties]
+ * @property {("e" | "m" | "h")[]} [difficultyModifiers]
  * @property {"bonus"} type
  *
  * @typedef {Question & BonusProperties} Bonus

--- a/types.js
+++ b/types.js
@@ -50,8 +50,8 @@ import { ObjectId } from 'mongodb';
  * @typedef {object} BonusProperties
  * @property {string} leadin
  * @property {string[]} parts
- * @property {string[]} answers
- * @property {string[]} [formatted_answers]
+ * @property {string[]} unformatted_answers
+ * @property {string[]} formatted_answers
  * @property {number[]} [values]
  * @property {("e" | "m" | "h")[]} [difficulties]
  * @property {"bonus"} type

--- a/types.js
+++ b/types.js
@@ -38,8 +38,8 @@ import { ObjectId } from 'mongodb';
 /**
  * @typedef {object} TossupProperties
  * @property {string} question
- * @property {string} answer
- * @property {string} [formatted_answer]
+ * @property {string} unformatted_answer
+ * @property {string} formatted_answer
  * @property {"tossup"} type
  *
  * @typedef {Question & TossupProperties} Tossup

--- a/types.js
+++ b/types.js
@@ -22,17 +22,8 @@ import { ObjectId } from 'mongodb';
  * @property {string} set.name
  * @property {number} set.year
  *
- * @property {"tossup" | "bonus"} type
  * @property {Date} createdAt
  * @property {Date} updatedAt
- *
- * @property {string} [packetName] Deprecated
- * @property {number} [packetNumber] Deprecated
- * @property {ObjectId} [packet_id] Deprecated
- * @property {number} questionNumber Deprecated
- * @property {string} [setName] Deprecated
- * @property {number} [setYear] Deprecated
- * @property {ObjectId} [set_id] Deprecated
  */
 
 /**
@@ -40,7 +31,6 @@ import { ObjectId } from 'mongodb';
  * @property {string} question
  * @property {string} answer_sanitized
  * @property {string} answer
- * @property {"tossup"} type
  *
  * @typedef {Question & TossupProperties} Tossup
  */
@@ -54,7 +44,6 @@ import { ObjectId } from 'mongodb';
  * @property {string[]} answers
  * @property {number[]} [values]
  * @property {("e" | "m" | "h")[]} [difficultyModifiers]
- * @property {"bonus"} type
  *
  * @typedef {Question & BonusProperties} Bonus
  */

--- a/types.js
+++ b/types.js
@@ -51,7 +51,7 @@ import { ObjectId } from 'mongodb';
  * @property {string} leadin
  * @property {string[]} parts
  * @property {string[]} answers_sanitized
- * @property {string[]} formatted_answers
+ * @property {string[]} answers
  * @property {number[]} [values]
  * @property {("e" | "m" | "h")[]} [difficulties]
  * @property {"bonus"} type


### PR DESCRIPTION
Rename the following fields to better align with modaq/buzzpoints:

Tossups:
- `unformatted_question` -> `question_sanitized`
- `unformatted_answer` -> `answer_sanitized`
- `formatted_answer` -> `answer`

Bonuses:
- `unformatted_leadin` -> `leadin_sanitized`
- `unformatted_parts` -> `parts_sanitized`
- `unformatted_answers` -> `answers_sanitized`
- `formatted_answers` -> `answers`

Also, include the bolding of power in the question field (instead of calculating it ourselves).