### PR TITLE
fix: prevent non-numbers from being used as reading speed

### DIFF
--- a/server/TossupRoom.js
+++ b/server/TossupRoom.js
@@ -277,6 +277,10 @@ class TossupRoom {
             break;
 
         case 'reading-speed':
+            if (isNaN(message.value)) {
+                return;
+            }
+
             this.settings.readingSpeed = message.value;
             this.sendSocketMessage({
                 type: 'reading-speed',


### PR DESCRIPTION
a malicious-intending user could use one line of code to instantly show each question:
```js
socket.send(JSON.stringify({"type":"reading-speed","value":"a"}));
```
i have fixed this by using `isNaN` to check if the value is really a number or not, and preventing the change if it isn't. `isNaN` also works on a string and checks if the string is a number.