### PR TITLE
Make the threshold be the floor of 3/4 of current players

### DIFF
--- a/server/multiplayer/ServerTossupRoom.js
+++ b/server/multiplayer/ServerTossupRoom.js
@@ -292,7 +292,7 @@ export default class ServerTossupRoom extends TossupRoom {
       }
     });
 
-    const threshold = Math.max(activePlayers - 2, 2);
+    const threshold = Math.max(Math.floor(activePlayers * 3 / 4), 2);
     const votekick = new Votekick(targetId, threshold, []);
     votekick.vote(userId);
     if (votekick.check()) {


### PR DESCRIPTION
A current issue in rooms is that while a majority of players are voting to remove a player they are short by 1 - 2 votes. By using 75% of total players this should fix that problem. Still an issue up to debate