### PR TITLE
Fix votekick

### DIFF
--- a/server/multiplayer/ServerTossupRoom.js
+++ b/server/multiplayer/ServerTossupRoom.js
@@ -291,6 +291,7 @@ export default class ServerTossupRoom extends TossupRoom {
     const threshold = Math.max(Math.floor(activePlayers * 3 / 4), 2);
     const votekick = new Votekick(targetId, threshold, []);
     votekick.vote(userId);
+    this.votekickList.push(votekick);
     if (votekick.check()) {
       this.emitMessage({ type: 'successful-vk', targetUsername, targetId });
       this.kickedUserList.set(targetId, Date.now());


### PR DESCRIPTION
Votekick was not working because the actual votekick object was not being added to the list of votekicks for the room. Luckily this is a simple fix. 