### PR TITLE
Preserve buzzpoint when creating tossup cards

### DIFF
--- a/client/scripts/utilities/index.js
+++ b/client/scripts/utilities/index.js
@@ -134,7 +134,7 @@ const createTossupCard = (function () {
 
     questionCounter++;
 
-    const { question, answer, category, subcategory, alternate_subcategory: alternateSubcategory, set, packet, number, _id } = tossup;
+    const {markedQuestion, answer, category, subcategory, alternate_subcategory: alternateSubcategory, set, packet, number, _id, buzzpoints} = tossup;
 
     // append a card containing the question to the history element
     const card = document.createElement('div');
@@ -152,7 +152,7 @@ const createTossupCard = (function () {
             </div>
             <div class="card-container collapse" id="question-${questionCounter}">
                 <div class="card-body">
-                    ${question}
+                    ${markedQuestion}
                     <a class="user-select-none" href="#" id="report-question-${_id}" data-bs-toggle="modal" data-bs-target="#report-question-modal">Report Question</a>
                     <hr></hr>
                     <div>ANSWER: ${answer}</div>

--- a/client/scripts/utilities/index.js
+++ b/client/scripts/utilities/index.js
@@ -134,7 +134,7 @@ const createTossupCard = (function () {
 
     questionCounter++;
 
-    const {markedQuestion, answer, category, subcategory, alternate_subcategory: alternateSubcategory, set, packet, number, _id} = tossup;
+    const { markedQuestion, answer, category, subcategory, alternate_subcategory: alternateSubcategory, set, packet, number, _id } = tossup;
 
     // append a card containing the question to the history element
     const card = document.createElement('div');

--- a/client/scripts/utilities/index.js
+++ b/client/scripts/utilities/index.js
@@ -134,7 +134,7 @@ const createTossupCard = (function () {
 
     questionCounter++;
 
-    const {markedQuestion, answer, category, subcategory, alternate_subcategory: alternateSubcategory, set, packet, number, _id, buzzpoints} = tossup;
+    const {markedQuestion, answer, category, subcategory, alternate_subcategory: alternateSubcategory, set, packet, number, _id} = tossup;
 
     // append a card containing the question to the history element
     const card = document.createElement('div');

--- a/quizbowl/TossupRoom.js
+++ b/quizbowl/TossupRoom.js
@@ -275,6 +275,7 @@ export default class TossupRoom extends QuestionRoom {
     if (Object.keys(this.tossup || {}).length === 0) return;
 
     this.tossupProgress = TOSSUP_PROGRESS_ENUM.ANSWER_REVEALED;
+    this.tossup.markedQuestion = insertTokensIntoHTML(this.tossup.question, this.tossup.question_sanitized, [this.buzzpointIndices], [' (#) ']);
     this.emitMessage({
       type: 'reveal-answer',
       question: insertTokensIntoHTML(this.tossup.question, this.tossup.question_sanitized, [this.buzzpointIndices], [' (#) ']),


### PR DESCRIPTION
As mentioned in issue #345 it would be nice to indicate buzzpoints in the question cards. Luckily, this is very simple.