### PR TITLE
Adjust reading time calculation in TossupRoom.js

### DIFF
--- a/quizbowl/TossupRoom.js
+++ b/quizbowl/TossupRoom.js
@@ -271,7 +271,7 @@ export default class TossupRoom extends QuestionRoom {
       time = 0;
     }
 
-    time = time * 0.9 * (150 - this.settings.readingSpeed);
+    time = time * 0.9 * (140 - this.settings.readingSpeed);
     const delay = time - Date.now() + expectedReadTime;
 
     this.timeoutID = setTimeout(() => {


### PR DESCRIPTION
Some team members have requested that the minimum reading speed be slightly slower. After running some tests with users, I also found that the maximum speed feels too fast.

Given the line 
```
time = time * 0.9 * (125 - this.settings.readingSpeed);
```

Adjusting the constant to `140` addresses both issues. The reading speed at zero is now about 12% slower, which should be noticeable but not drastic. 