### PR TITLE
Get MongoDB URI from env

### DIFF
--- a/database/databases.js
+++ b/database/databases.js
@@ -1,6 +1,8 @@
 import { MongoClient } from 'mongodb';
 
-const uri = `mongodb+srv://${process.env.MONGODB_USERNAME || 'geoffreywu42'}:${process.env.MONGODB_PASSWORD || 'password'}@qbreader2.z35tynb.mongodb.net/?retryWrites=true&w=majority`;
+const uri =
+  process.env.MONGODB_URI ??
+  `mongodb+srv://${process.env.MONGODB_USERNAME || 'geoffreywu42'}:${process.env.MONGODB_PASSWORD || 'password'}@qbreader2.z35tynb.mongodb.net/?retryWrites=true&w=majority`;
 export const mongoClient = new MongoClient(uri);
 
 await mongoClient.connect();


### PR DESCRIPTION
Allows MongoDB URI to be specified using an env variable. This change supports running qbreader in a docker environment. See github.com/benjiec/qbreader-docker
