### PR TITLE
Add Distraction Free Mode

### DIFF
--- a/client/play/mp/room.html
+++ b/client/play/mp/room.html
@@ -198,6 +198,14 @@
                         <label class="form-check-label" for="toggle-timer">Enable timer</label>
                     </div>
                     <div class="form-check form-switch">
+                        <input class="form-check-input" id="toggle-distraction-free" type="checkbox" role="switch">
+                        <label class="form-check-label" for="toggle-distraction-free">
+                            Enable Distraction Free Mode
+                            <i class="bi bi-question-circle text-muted" data-bs-toggle="tooltip" data-bs-placement="top" 
+                               title="Hides all chat messages and shows all usernames as 'Player'. This change only affects you." style="font-size: 0.85em; cursor: help;"></i>
+                        </label>
+                    </div>
+                    <div class="form-check form-switch">
                         <input class="form-check-input" id="toggle-lock" type="checkbox" role="switch">
                         <label class="form-check-label" for="toggle-lock">Lock room from new players</label>
                     </div>

--- a/client/play/upsert-player-item.js
+++ b/client/play/upsert-player-item.js
@@ -5,9 +5,10 @@ import { escapeHTML } from '../scripts/utilities/strings.js';
  * @param {Player} player
  * @param {string} USER_ID - The item is highlighted blue if `USER_ID === player.userId`.
  * @param {string} ownerId - ID of the room owner
+ * @param {Object} room - The room object containing distractionFreeMode flag
  */
 // overall handling of some of these mechanics in the upsertion section might not be best idea? works though
-export default function upsertPlayerItem (player, USER_ID, ownerId, socket, isPublic, team) {
+export default function upsertPlayerItem (player, USER_ID, ownerId, socket, isPublic, team, room) {
   if (!player || !player.userId || !player.username) {
     console.error('Player or player.userId or player.username is undefined', { player });
     return;
@@ -23,6 +24,7 @@ export default function upsertPlayerItem (player, USER_ID, ownerId, socket, isPu
 
   const { userId, username, powers = 0, tens = 0, negs = 0, tuh = 0, points = 0, online } = player;
   const celerity = player?.celerity?.correct?.average ?? player?.celerity ?? 0;
+  const displayUsername = window.getDisplayName ? window.getDisplayName(username, room?.distractionFreeMode || false) : username;
 
   const { bonusStats = { 0: 0, 10: 0, 20: 0, 30: 0 } } = team;
   const bonusPoints = Object.entries(bonusStats).map(([pointValue, count]) => pointValue * count).reduce((a, b) => a + b, 0);
@@ -38,12 +40,12 @@ export default function upsertPlayerItem (player, USER_ID, ownerId, socket, isPu
   const playerItem = document.createElement('a');
   playerItem.className = `list-group-item clickable ${userId === USER_ID ? 'user-score' : ''} ${online === false && 'offline'}`;
   playerItem.id = `list-group-${userId}`;
-  const displayUsername = (playerIsOwner && !isPublic) ? `👑 ${username}` : username;
+  const crownDisplayUsername = (playerIsOwner && !isPublic) ? `👑 ${displayUsername}` : displayUsername;
 
   playerItem.innerHTML = `
   <div class="d-flex justify-content-between align-items-center">
       <div class="d-flex align-items-center">
-          <span id="username-${userId}" class="me-1">${displayUsername}</span>
+          <span id="username-${userId}" class="me-1">${crownDisplayUsername}</span>
           <!-- Dropdown  -->
       </div>
       <span><span id="points-${userId}" class="badge rounded-pill ${online ? 'bg-success' : 'bg-secondary'}">${points + bonusPoints}</span></span>


### PR DESCRIPTION
Fixes #435

## Summary
Adds a Distraction-Free Mode for multiplayer lobbies.

## What This Does
- Hides chat messages
- Displays all usernames as "Player"
- Adds a toggle switch in lobby settings to toggle DFM

## Testing
Tested locally in multiplayer lobbies with no issues observed.
