### PR TITLE
Adding verified rooms

### DIFF
--- a/client/play/mp/MultiplayerTossupBonusClient.js
+++ b/client/play/mp/MultiplayerTossupBonusClient.js
@@ -135,6 +135,7 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
     canBuzz,
     currentQuestionType,
     isPermanent,
+    isVerified,
     ownerId,
     mode,
     packetLength,
@@ -146,6 +147,8 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
     userId
   }) {
     this.room.bonusEligibleTeamId = bonusEligibleTeamId;
+    this.room.isPermanent = isPermanent;
+    this.room.isVerified = isVerified;
     this.room.public = settings.public;
     this.room.ownerId = ownerId;
     this.room.setLength = packetCount;
@@ -159,10 +162,16 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
       document.getElementById('category-select-button').disabled = true;
       document.getElementById('toggle-enable-bonuses').disabled = true;
       document.getElementById('permanent-room-warning').classList.remove('d-none');
+      document.getElementById('permanent-room-warning').textContent = isVerified
+        ? 'This is a verified room. Login is required and some settings have been restricted.'
+        : 'This is a permanent room. Some settings have been restricted.';
       document.getElementById('reading-speed').disabled = true;
       document.getElementById('set-strictness').disabled = true;
       document.getElementById('set-mode').disabled = true;
       document.getElementById('toggle-public').disabled = true;
+      if (isVerified) {
+        document.getElementById('toggle-login-required').disabled = true;
+      }
     }
 
     for (const userId of Object.keys(players)) {
@@ -716,7 +725,9 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
     this.room.public = isPublic;
     if (isPublic) {
       document.getElementById('toggle-lock').checked = false;
-      document.getElementById('toggle-login-required').checked = false;
+      if (!this.room.isVerified) {
+        document.getElementById('toggle-login-required').checked = false;
+      }
       this.toggleTimer({ timer: true });
     }
     Object.entries(this.room.players).forEach(([playerId, player]) => {

--- a/client/play/mp/index.html
+++ b/client/play/mp/index.html
@@ -119,6 +119,10 @@
             </div>
         </form>
         <hr>
+        <div id="verified-rooms-section" class="d-none">
+            <p>Verified rooms (login required):</p>
+            <ul class="list-group mb-3" id="verified-room-list"></ul>
+        </div>
         <p>Try one of these rooms:</p>
         <ul class="list-group mb-3" id="permanent-room-list"></ul>
         <div class="d-flex justify-content-between mb-3">

--- a/routes/api/multiplayer/room-list.js
+++ b/routes/api/multiplayer/room-list.js
@@ -17,6 +17,7 @@ router.get('/', (req, res) => {
 
     roomList.push({
       isPermanent: tossupBonusRooms[roomName].isPermanent,
+      isVerified: tossupBonusRooms[roomName].isVerified ?? false,
       onlineCount,
       playerCount: Object.keys(tossupBonusRooms[roomName].players).length,
       roomName

--- a/server/multiplayer/ServerMultiplayerRoomMixin.js
+++ b/server/multiplayer/ServerMultiplayerRoomMixin.js
@@ -19,10 +19,11 @@ import Team from '../../quizbowl/Team.js';
 const BAN_DURATION = 1000 * 60 * 30; // 30 minutes
 
 const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
-  constructor (name, ownerId, isPermanent, categoryManager, supportedQuestionTypes) {
+  constructor (name, ownerId, isPermanent, categoryManager, supportedQuestionTypes, isVerified = false) {
     super(name, categoryManager, supportedQuestionTypes);
     this.ownerId = ownerId;
     this.isPermanent = isPermanent;
+    this.isVerified = isVerified;
     this.checkAnswer = checkAnswer;
     this.getPacketCount = getNumPackets;
 
@@ -40,7 +41,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
     this.settings = {
       ...this.settings,
       lock: false,
-      loginRequired: false,
+      loginRequired: isVerified,
       public: true,
       controlled: false
     };
@@ -145,6 +146,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
       canBuzz: this.settings.rebuzz || !this.buzzes.includes(userId),
       currentQuestionType: this.currentQuestionType,
       isPermanent: this.isPermanent,
+      isVerified: this.isVerified,
       mode: this.mode,
       ownerId: this.ownerId,
       packetLength: this.packetCount,
@@ -347,7 +349,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
   }
 
   toggleLoginRequired (userId, { loginRequired }) {
-    if (this.settings.public || !this.allowed(userId)) { return; }
+    if (this.isVerified || this.settings.public || !this.allowed(userId)) { return; }
     this.settings.loginRequired = loginRequired;
     const username = this.players[userId].username;
     this.emitMessage({ type: 'toggle-login-required', loginRequired, username });

--- a/server/multiplayer/ServerTossupBonusRoom.js
+++ b/server/multiplayer/ServerTossupBonusRoom.js
@@ -3,8 +3,8 @@ import TossupBonusRoom from '../../quizbowl/TossupBonusRoom.js';
 import { QUESTION_TYPE_ENUM, TOSSUP_PROGRESS_ENUM } from '../../quizbowl/constants.js';
 
 export default class ServerTossupBonusRoom extends ServerMultiplayerRoomMixin(TossupBonusRoom) {
-  constructor (name, ownerId, isPermanent, categoryManager) {
-    super(name, ownerId, isPermanent, categoryManager, ['tossups', 'bonuses']);
+  constructor (name, ownerId, isPermanent, categoryManager, isVerified = false) {
+    super(name, ownerId, isPermanent, categoryManager, ['tossups', 'bonuses'], isVerified);
   }
 
   giveAnswerLiveUpdate (userId, { givenAnswer }) {

--- a/server/multiplayer/constants.js
+++ b/server/multiplayer/constants.js
@@ -60,3 +60,13 @@ export const PERMANENT_ROOMS = [
     subcategories: CATEGORY_TO_SUBCATEGORY['Pop Culture']
   }
 ];
+
+/**
+ * Verified rooms
+ * Same categories as permanent rooms, with verified- prefix.
+ */
+export const VERIFIED_ROOMS = PERMANENT_ROOMS.map(room => ({
+  name: `verified-${room.name}`,
+  categories: room.categories,
+  subcategories: room.subcategories
+}));

--- a/server/multiplayer/handle-wss-connection.js
+++ b/server/multiplayer/handle-wss-connection.js
@@ -1,4 +1,4 @@
-import { MAX_ONLINE_PLAYERS, PERMANENT_ROOMS, ROOM_NAME_MAX_LENGTH } from './constants.js';
+import { MAX_ONLINE_PLAYERS, PERMANENT_ROOMS, VERIFIED_ROOMS, ROOM_NAME_MAX_LENGTH } from './constants.js';
 import ServerTossupBonusRoom from './ServerTossupBonusRoom.js';
 import { checkToken } from '../authentication.js';
 import CategoryManager from '../../quizbowl/category-manager.js';
@@ -22,7 +22,13 @@ export const tossupBonusRooms = {};
 for (const room of PERMANENT_ROOMS) {
   const { name, categories, subcategories } = room;
   tossupBonusRooms[name] = new ServerTossupBonusRoom(
-    name, Symbol('unique permanent room owner'), true, new CategoryManager(categories, subcategories)
+    name, Symbol('unique permanent room owner'), true, new CategoryManager(categories, subcategories), false
+  );
+}
+for (const room of VERIFIED_ROOMS) {
+  const { name, categories, subcategories } = room;
+  tossupBonusRooms[name] = new ServerTossupBonusRoom(
+    name, Symbol('unique verified room owner'), true, new CategoryManager(categories, subcategories), true
   );
 }
 


### PR DESCRIPTION
Adds clones of the permanent rooms that require email verification. This is to combat the botting issue. Per suggestion the rooms aren't visible in the list unless verified, but this is easily changeable.

I tested (mongo locally):

- Verified rooms
- - Rejects unverified and logged out users
- - Accepts verified users
- - Verified-only locked
- Permanent (non verified) rooms
- - Accepts all users
- - Verified-only locked
- Private rooms
- - Everything still works the exact same