### PR TITLE
Fix missing 0 in initial stats

### DIFF
--- a/client/play/tossups/index.html
+++ b/client/play/tossups/index.html
@@ -212,7 +212,7 @@
                     </div>
                 </form>
                 <div class="d-flex justify-content-between">
-                    <span id="statline">0/0/0 with 0 tossups seen (0 pts, celerity: 0)</span>
+                    <span id="statline">0/0/0/0 with 0 tossups seen (0 pts, celerity: 0)</span>
                     <span class="ps-5 me-lg-2" id="question-metadata">
                         <b id="question-info">
                             <span id="set-name-info"></span>


### PR DESCRIPTION
Added the missing 0 in the initial stats page for singleplayer tossups - it updates to show the superpowers once a question is answered (e.g. 1/0/0/0) but only shows 0/0/0 beforehand