### PR TITLE
fix: clear stats button also resets bonus points in multiplayer

### DIFF
--- a/client/play/mp/MultiplayerTossupBonusClient.js
+++ b/client/play/mp/MultiplayerTossupBonusClient.js
@@ -116,9 +116,7 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
       player[field] = 0;
     }
     const team = this.room.teams[player.teamId];
-    if (team) {
-      team.bonusStats = { 0: 0, 10: 0, 20: 0, 30: 0 };
-    }
+    if (team) { team.bonusStats = { 0: 0, 10: 0, 20: 0, 30: 0 }; }
     upsertPlayerItem(player, { callerId: this.USER_ID, distractionFreeMode: this.distractionFreeMode, ownerId: this.room.ownerId, socket: this.socket, isPublic: this.room.public, team });
     this.sortPlayerListGroup();
   }

--- a/client/play/mp/MultiplayerTossupBonusClient.js
+++ b/client/play/mp/MultiplayerTossupBonusClient.js
@@ -115,7 +115,11 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
     for (const field of ['celerity', 'negs', 'points', 'powers', 'tens', 'tuh', 'zeroes']) {
       player[field] = 0;
     }
-    upsertPlayerItem(player, { callerId: this.USER_ID, distractionFreeMode: this.distractionFreeMode, ownerId: this.room.ownerId, socket: this.socket, isPublic: this.room.public, team: this.room.teams[player.teamId] });
+    const team = this.room.teams[player.teamId];
+    if (team) {
+      team.bonusStats = { 0: 0, 10: 0, 20: 0, 30: 0 };
+    }
+    upsertPlayerItem(player, { callerId: this.USER_ID, distractionFreeMode: this.distractionFreeMode, ownerId: this.room.ownerId, socket: this.socket, isPublic: this.room.public, team });
     this.sortPlayerListGroup();
   }
 


### PR DESCRIPTION
Resolves #472 
The issue was that even though the `BonusRoom.clearStats` resets `team.BonusStats`, the client side `clearStats` only affected the player's tossup points but never affects bonus points. 

pr adds a section in MultiplayerTossupBonusClient.js that resets the bonus stats in the `clearStats` function