### PR TITLE
Difficulty lock in some permanent rooms

### DIFF
--- a/client/play/mp/MultiplayerTossupBonusClient.js
+++ b/client/play/mp/MultiplayerTossupBonusClient.js
@@ -175,6 +175,7 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
       document.getElementById('set-strictness').disabled = true;
       document.getElementById('set-mode').disabled = true;
       document.getElementById('toggle-public').disabled = true;
+      document.getElementById('difficulties').querySelectorAll('input').forEach(input => { input.disabled = true; });
       if (isVerified) {
         document.getElementById('toggle-login-required').disabled = true;
       }

--- a/client/play/mp/MultiplayerTossupBonusClient.js
+++ b/client/play/mp/MultiplayerTossupBonusClient.js
@@ -138,6 +138,7 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
     buzzedIn,
     canBuzz,
     currentQuestionType,
+    fixedDifficulties,
     isPermanent,
     isVerified,
     ownerId,
@@ -175,10 +176,13 @@ export const MultiplayerClientMixin = (ClientClass) => class extends ClientClass
       document.getElementById('set-strictness').disabled = true;
       document.getElementById('set-mode').disabled = true;
       document.getElementById('toggle-public').disabled = true;
-      document.getElementById('difficulties').querySelectorAll('input').forEach(input => { input.disabled = true; });
       if (isVerified) {
         document.getElementById('toggle-login-required').disabled = true;
       }
+    }
+
+    if (fixedDifficulties) {
+      document.getElementById('difficulties').querySelectorAll('input').forEach(input => { input.disabled = true; });
     }
 
     for (const userId of Object.keys(players)) {

--- a/server/multiplayer/ServerMultiplayerRoomMixin.js
+++ b/server/multiplayer/ServerMultiplayerRoomMixin.js
@@ -24,6 +24,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
     this.ownerId = ownerId;
     this.isPermanent = isPermanent;
     this.isVerified = isVerified;
+    this.fixedDifficulties = false;
     this.checkAnswer = checkAnswer;
     this.getPacketCount = getNumPackets;
 
@@ -148,6 +149,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
       canBuzz: this.settings.rebuzz || !this.buzzes.includes(userId),
       currentQuestionType: this.currentQuestionType,
       isPermanent: this.isPermanent,
+      fixedDifficulties: this.fixedDifficulties,
       isVerified: this.isVerified,
       mode: this.mode,
       ownerId: this.ownerId,
@@ -278,7 +280,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
   }
 
   setDifficulties ({ userId, username }, { difficulties }) {
-    if (this.isPermanent || !this.allowed(userId)) { return; }
+    if (this.fixedDifficulties || !this.allowed(userId)) { return; }
     super.setDifficulties({ userId, username }, { difficulties });
   }
 

--- a/server/multiplayer/ServerMultiplayerRoomMixin.js
+++ b/server/multiplayer/ServerMultiplayerRoomMixin.js
@@ -277,6 +277,11 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
     super.setCategories({ userId, username }, { categories, subcategories, alternateSubcategories, percentView, categoryPercents });
   }
 
+  setDifficulties ({ userId, username }, { difficulties }) {
+    if (this.isPermanent || !this.allowed(userId)) { return; }
+    super.setDifficulties({ userId, username }, { difficulties });
+  }
+
   setMode ({ userId, username }, { mode }) {
     if (this.isPermanent || !this.allowed(userId)) { return; }
     if (this.mode !== MODE_ENUM.SET_NAME && this.mode !== MODE_ENUM.RANDOM) { return; }

--- a/server/multiplayer/constants.js
+++ b/server/multiplayer/constants.js
@@ -13,17 +13,23 @@ export const PERMANENT_ROOMS = [
   {
     name: 'msquizbowl',
     categories: CATEGORIES,
-    subcategories: SUBCATEGORIES
+    subcategories: SUBCATEGORIES,
+    difficulties: [1],
+    fixedDifficulties: true
   },
   {
     name: 'hsquizbowl',
     categories: CATEGORIES,
-    subcategories: SUBCATEGORIES
+    subcategories: SUBCATEGORIES,
+    difficulties: [2, 3],
+    fixedDifficulties: true
   },
   {
     name: 'collegequizbowl',
     categories: CATEGORIES,
-    subcategories: SUBCATEGORIES
+    subcategories: SUBCATEGORIES,
+    difficulties: [7, 8, 9],
+    fixedDifficulties: true
   },
   {
     name: 'literature',

--- a/server/multiplayer/handle-wss-connection.js
+++ b/server/multiplayer/handle-wss-connection.js
@@ -21,16 +21,22 @@ const DOMPurify = createDOMPurify(window);
 export const tossupBonusRooms = {};
 const connectionsByIp = new Map();
 for (const room of PERMANENT_ROOMS) {
-  const { name, categories, subcategories } = room;
-  tossupBonusRooms[name] = new ServerTossupBonusRoom(
+  const { name, categories, subcategories, difficulties, fixedDifficulties = false } = room;
+  const r = new ServerTossupBonusRoom(
     name, Symbol('unique permanent room owner'), true, new CategoryManager(categories, subcategories), false
   );
+  if (difficulties) { r.query.difficulties = difficulties; }
+  r.fixedDifficulties = fixedDifficulties;
+  tossupBonusRooms[name] = r;
 }
 for (const room of VERIFIED_ROOMS) {
-  const { name, categories, subcategories } = room;
-  tossupBonusRooms[name] = new ServerTossupBonusRoom(
+  const { name, categories, subcategories, difficulties, fixedDifficulties = false } = room;
+  const r = new ServerTossupBonusRoom(
     name, Symbol('unique verified room owner'), true, new CategoryManager(categories, subcategories), true
   );
+  if (difficulties) { r.query.difficulties = difficulties; }
+  r.fixedDifficulties = fixedDifficulties;
+  tossupBonusRooms[name] = r;
 }
 
 /**


### PR DESCRIPTION
This pr prevents players from changing the difficulties of msquizbowl, hsquizbowl, and collegequizbowl by adding a server side `setDifficulties()` function and restricting input on the client side code for the difficulties dropdown in client/play/mp/MultiplayerTossupBonusClient.js