### PR TITLE
fix: reveal tossup answer when all remaining players have buzzed

### DIFF
--- a/quizbowl/TossupRoom.js
+++ b/quizbowl/TossupRoom.js
@@ -132,7 +132,7 @@ export const TossupRoomMixin = (QuestionRoomClass) => class extends QuestionRoom
       case 'reject':
         this.buzzedIn = null;
         this.players[userId].updateStats(points, celerity);
-        if (!this.settings.rebuzz && this.buzzes.length === Object.keys(this.sockets).length) {
+        if (!this.settings.rebuzz && Object.keys(this.sockets).every(id => this.buzzes.includes(id))) {
           this.revealTossupAnswer();
           Object.values(this.players).forEach(player => { player.tuh++; });
         } else {


### PR DESCRIPTION
## Summary

`quizbowl/TossupRoom.js` decides whether to reveal the answer after a neg by checking `this.buzzes.length === Object.keys(this.sockets).length`. But `this.buzzes` is only reset between tossups (`endCurrentTossup`) — `Room.leave()` removes the userId from `this.sockets` and never touches `this.buzzes`. So once a player negs and leaves, the buzz array carries a stale entry forever, and the equality check drifts out of sync with the actual room population.

### Failure scenario

1. Players A and B are in a room with `rebuzz` off.
2. A buzzes and negs → `buzzes = [A]`, `sockets = {A, B}` (1 ≠ 2, reading resumes — correct).
3. A leaves → `buzzes = [A]` (stale), `sockets = {B}`.
4. B buzzes and negs → `buzzes = [A, B]`, `sockets = {B}` (2 ≠ 1, answer is **not** revealed even though every player still in the room has already buzzed).

A symmetric variant (A negs, B leaves without buzzing) makes the answer reveal after a single neg, which is also wrong when `rebuzz` is off.

### Fix

Replace the length comparison with "every current socket has already buzzed":

```js
Object.keys(this.sockets).every(id => this.buzzes.includes(id))
```

This ignores ghost entries left behind by departed players and correctly accounts for newly joined players who haven't buzzed yet (they'll be in `sockets` but not in `buzzes`, so the answer won't prematurely reveal).

## Test plan

- [ ] Two-player room, `rebuzz` off: player A buzzes/negs, leaves, player B buzzes/negs → answer is revealed.
- [ ] Two-player room, `rebuzz` off: player A buzzes/negs, player B joins mid-tossup → reading continues until B also buzzes or the question ends (no premature reveal).
- [ ] Single-player room, `rebuzz` off: solo player negs → answer revealed (unchanged behavior).
- [ ] `rebuzz` on: behavior unchanged (the whole branch is gated on `!this.settings.rebuzz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)