### PR TITLE
security: prevent username enumeration on password reset

### DIFF
--- a/routes/auth/send-password-reset-email.js
+++ b/routes/auth/send-password-reset-email.js
@@ -5,11 +5,8 @@ import { Router } from 'express';
 const router = Router();
 
 router.get('/', async (req, res) => {
-  if (await sendResetPasswordEmail(req.query.username)) {
-    res.redirect(200, '/');
-  } else {
-    res.redirect(500, '/');
-  }
+  await sendResetPasswordEmail(req.query.username);
+  res.redirect(200, '/');
 });
 
 export default router;


### PR DESCRIPTION
Always responds with a 200 redirect regardless of whether the username exists, preventing attackers from using the HTTP status code to enumerate valid accounts.

## Problem
In `routes/auth/send-password-reset-email.js`, the handler returned `res.redirect(200, '/')` on success and `res.redirect(500, '/')` on failure. An attacker could probe usernames by watching the response code — a 500 confirmed the account did not exist (or the email failed).

## Changes
- Removes the success/failure branch; `sendResetPasswordEmail` is still awaited so unexpected server errors surface as unhandled exceptions rather than being swallowed.
- Unconditionally responds `res.redirect(200, '/')`, matching standard practice for password reset flows.

## Risk & testing
Logic change is minimal — one code path removed, no new state introduced. The `sendResetPasswordEmail` call is preserved so email delivery behavior is unchanged. `node --check` passes.