### PR TITLE
security: set httpOnly, secure, and sameSite on the session cookie

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,10 @@ app.use(express.json());
 app.use(cookieSession({
   name: 'session',
   keys: [process.env.SECRET_KEY_1 ?? 'secretKey1', process.env.SECRET_KEY_2 ?? 'secretKey2'],
-  maxAge: COOKIE_MAX_AGE
+  maxAge: COOKIE_MAX_AGE,
+  httpOnly: true,
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production'
 }));
 
 app.use(ipFilterMiddleware);


### PR DESCRIPTION
Hardens the `cookie-session` configuration, which previously set none of the standard cookie security flags.

## Problem
In `app.js`, the session cookie declared only `name`, `keys`, and `maxAge`:
- no `httpOnly` — readable by client-side JavaScript (session theft via XSS)
- no `secure` — can be transmitted over plain HTTP (MITM interception)
- no `sameSite` — sent on cross-site requests (CSRF)

## Changes
- Adds `httpOnly: true` and `sameSite: 'lax'`.
- Adds `secure: process.env.NODE_ENV === 'production'`, so cookies are HTTPS-only in production (the app already calls `app.enable('trust proxy')`, so this works behind the platform proxy) while local HTTP development keeps working.

## Risk & testing
Configuration-only change, no application logic altered. `secure` is gated to production so local dev over HTTP is unaffected. `semistandard` and `node --check` pass.