### PR TITLE
perf: cache rendered SSI HTML in ssi-middleware to avoid repeated disk reads

### DIFF
--- a/routes/ssi-middleware.js
+++ b/routes/ssi-middleware.js
@@ -4,16 +4,23 @@ import path from 'path';
 const head = fs.readFileSync('./client/ssi/head.html', 'utf8');
 const nav = fs.readFileSync('./client/ssi/nav.html', 'utf8');
 
+// cache rendered HTML per file; files are static between deploys
+const cache = new Map();
+
 export default function (req, res, next) {
   if (path.extname(req.path) !== '') { return next(); }
 
   const filePath = path.resolve('./client' + req.path + (req.path.slice(-1) === '/' ? 'index.html' : '.html'));
   // prevent directory traversal attack
   if (!filePath.startsWith(path.resolve('./client'))) { return next(); }
+
+  if (cache.has(filePath)) { return res.send(cache.get(filePath)); }
+
   fs.readFile(filePath, 'utf8', (err, data) => {
     if (err) return next();
     data = data.replace('<!--#include virtual="/ssi/head.html" -->', head);
     data = data.replace('<!--#include virtual="/ssi/nav.html" -->', nav);
+    cache.set(filePath, data);
     res.send(data);
   });
 }


### PR DESCRIPTION
Adds an in-process cache to the SSI middleware so each HTML page is read from disk and string-substituted only once per server lifetime instead of on every request.

## Problem
`routes/ssi-middleware.js` called `fs.readFile` and ran two `String.replace` operations on every page view. Because the HTML files and SSI partials (`head.html`, `nav.html`) are static between deploys, this work is entirely redundant after the first hit per path.

## Changes
- Introduces a `Map` keyed by resolved file path.
- On a cache hit, returns the pre-rendered string directly with `res.send`.
- On a miss, reads the file, applies SSI substitutions, stores the result, and responds as before.
- Errors (file not found, etc.) fall through to `next()` unchanged and are never cached.

## Risk & testing
The cache is populated lazily and is scoped to the server process lifetime, so a deploy naturally clears it. Error paths are unaffected. The directory-traversal guard runs before the cache lookup, so that protection is preserved. `node --check` passes.