### PR TITLE
a11y: add aria-current to active db-explorer pagination links

### DIFF
--- a/client/db/index.jsx
+++ b/client/db/index.jsx
@@ -418,7 +418,7 @@ function QueryForm () {
                   const isActive = tossupPaginationNumber === i + 1;
                   return (
                     <li key={`tossup-pagination-${i + 1}`} className='page-item'>
-                      <a className={`page-link ${isActive && 'active'}`} href='#' onClick={event => { handleTossupPaginationClick(event, i + 1); }}>
+                      <a className={`page-link ${isActive ? 'active' : ''}`} aria-current={isActive ? 'page' : undefined} href='#' onClick={event => { handleTossupPaginationClick(event, i + 1); }}>
                         {i + 1}
                       </a>
                     </li>
@@ -477,7 +477,7 @@ function QueryForm () {
                 const isActive = bonusPaginationNumber === i + 1;
                 return (
                   <li key={`bonus-pagination-${i + 1}`} className='page-item'>
-                    <a className={`page-link ${isActive && 'active'}`} href='#' onClick={event => { handleBonusPaginationClick(event, i + 1); }}>
+                    <a className={`page-link ${isActive ? 'active' : ''}`} aria-current={isActive ? 'page' : undefined} href='#' onClick={event => { handleBonusPaginationClick(event, i + 1); }}>
                       {i + 1}
                     </a>
                   </li>


### PR DESCRIPTION
The tossup and bonus pagination in `client/db/index.jsx` was inaccessible to screen readers: the active page had no semantic marker, so assistive technologies announced all page links identically with no way to distinguish the current one.

## Problem

In both the tossup and bonus pagination loops, the active page link was identified only by a CSS class:

```jsx
<a className={`page-link ${isActive && 'active'}`} href='#' ...>
```

Two issues:
1. No `aria-current` attribute — screen readers cannot identify the current page.
2. `isActive && 'active'` evaluates to the boolean `false` (not an empty string) when inactive, injecting the literal text `"false"` into the `className` string.

## Changes

- Adds `aria-current={isActive ? 'page' : undefined}` to the active page `<a>` in both the tossup (`line 421`) and bonus (`line 480`) pagination loops.
- Fixes the class expression to `${isActive ? 'active' : ''}` to eliminate the spurious `"false"` class name.

## Risk & testing

Two-line mechanical change per pagination component. The visual rendering is identical for sighted users; only the DOM attribute and class string differ. `semistandard` and `node --check` pass.