### PR TITLE
fix: catch adjustQuery errors to prevent unhandled rejection crash

### DIFF
--- a/quizbowl/QuestionRoom.js
+++ b/quizbowl/QuestionRoom.js
@@ -111,18 +111,25 @@ export default class QuestionRoom extends Room {
 
     if (doNotFetch) { return; }
 
-    switch (this.mode) {
-      case MODE_ENUM.SET_NAME:
-        this.packet = await this.getPacket({ setName: this.query.setName, packetNumber: this.query.packetNumbers[0] });
-        break;
-      case MODE_ENUM.RANDOM:
-        for (const s of this.supportedQuestionTypes) {
-          const query = { ...this.query, number: 1 };
-          this.randomQuestionCache[s] = this.categoryManager.percentView
-            ? []
-            : await this.getRandomQuestions(s, query);
-        }
-        break;
+    try {
+      switch (this.mode) {
+        case MODE_ENUM.SET_NAME:
+          this.packet = await this.getPacket({ setName: this.query.setName, packetNumber: this.query.packetNumbers[0] });
+          break;
+        case MODE_ENUM.RANDOM:
+          for (const s of this.supportedQuestionTypes) {
+            const query = { ...this.query, number: 1 };
+            this.randomQuestionCache[s] = this.categoryManager.percentView
+              ? []
+              : await this.getRandomQuestions(s, query);
+          }
+          break;
+      }
+    } catch (error) {
+      // adjustQuery is invoked fire-and-forget from message handlers, so a
+      // rejected DB call here would become an unhandled rejection and crash
+      // the process. Log and bail; the next getNextQuestion will refetch.
+      console.error(`adjustQuery failed to fetch questions in room ${this.name}:`, error);
     }
   }
 


### PR DESCRIPTION
`adjustQuery` in `quizbowl/QuestionRoom.js` awaits database calls (`getPacket`, `getRandomQuestions`) but is invoked fire-and-forget from synchronous message handlers with no `await` or `.catch`. A transient DB error produces an unhandled promise rejection, which terminates the Node process on Node 15+.

## Problem

Every call site invokes `adjustQuery` without catching its return value:

```js
// e.g. in a message handler
this.adjustQuery(...);  // no await, no .catch
```

If `getPacket` or `getRandomQuestions` throws — for instance during a brief MongoDB hiccup — the rejection escapes `adjustQuery` with no handler. Node 15+ converts unhandled rejections to fatal crashes, taking down all active rooms.

## Changes

- Wraps the `switch` block inside `adjustQuery` in a `try/catch`.
- On error, logs via `console.error` (including the room name) and returns early.
- The query fields (`this.query`) are still updated before the fetch, so the next `getNextQuestion` call will refetch correctly.

## Risk & testing

The happy path is unchanged. The change is conservative: it contains the failure at a single point rather than requiring a `.catch` at every call site. `semistandard` and `node --check` pass.