### PR TITLE
fix: remove completed and expired votekick entries from votekickList

### DIFF
--- a/server/multiplayer/ServerMultiplayerRoomMixin.js
+++ b/server/multiplayer/ServerMultiplayerRoomMixin.js
@@ -236,6 +236,8 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
         this.kickedUserList.delete(userId);
       }
     });
+
+    this.votekickList = this.votekickList.filter(votekick => now - votekick.createdAt <= BAN_DURATION);
   }
 
   closeConnection ({ userId, username }) {
@@ -427,6 +429,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
     if (votekick.check()) {
       this.emitMessage({ type: 'successful-vk', targetUsername, targetId });
       this.kickedUserList.set(targetId, Date.now());
+      this.votekickList = this.votekickList.filter(vk => !vk.exists(targetId));
     } else {
       this.kickedUserList.set(targetId, Date.now());
       this.emitMessage({ type: 'initiated-vk', targetUsername, threshold });
@@ -455,6 +458,7 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
     if (thisVotekick.check()) {
       this.emitMessage({ type: 'successful-vk', targetUsername, targetId });
       this.kickedUserList.set(targetId, Date.now());
+      this.votekickList = this.votekickList.filter(vk => !vk.exists(targetId));
 
       setTimeout(() => this.closeConnection({ userId: targetId, username: targetUsername }), 1000);
 

--- a/server/multiplayer/VoteKick.js
+++ b/server/multiplayer/VoteKick.js
@@ -3,6 +3,7 @@ export default class Votekick {
     this.targetId = targetId;
     this.voted = Array.isArray(voted) ? voted : [];
     this.threshold = threshold;
+    this.createdAt = Date.now();
   }
 
   exists (givenId) {


### PR DESCRIPTION
Completed and abandoned votekick entries were never removed from `votekickList` in `ServerMultiplayerRoomMixin.js`, causing two distinct problems: the list grew without bound in long-lived rooms (slow memory leak), and a successful or expired votekick permanently blocked any future votekick against the same user until the server restarted.

## Problem

`votekickInit` short-circuits if an entry for the target already exists:

```js
if (this.votekickList.find(vk => vk.exists(targetId))) { return; }
```

Because entries were never pruned, a completed kick — or one that simply expired — would prevent any re-initiation for that user for the lifetime of the server process. In rooms with heavy moderation activity, the list also accumulated unboundedly.

## Changes

- Adds `this.createdAt = Date.now()` to the `Votekick` constructor (`VoteKick.js`) so entries carry a timestamp.
- Removes a target's entry from `votekickList` on the successful `check()` branch in both `votekickInit` and `votekickVote`, so a re-initiation is possible if the user rejoins after being kicked.
- Prunes stale entries inside the existing `cleanupExpiredBansAndKicks` method using `BAN_DURATION` as the TTL, consistent with how bans and kicks are already expired.

## Risk & testing

In-progress votes are never disrupted: entries are only removed on success or after the TTL window has passed. The `cleanupExpiredBansAndKicks` pruning is additive — the surrounding ban/kick cleanup is unchanged. `semistandard` and `node --check` pass.