### PR TITLE
security: add X-Content-Type-Options, X-Frame-Options, and Referrer-Policy headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,15 @@ if (process.env.NODE_ENV !== 'production') {
   app.use(morgan('dev'));
 }
 
+app.use((req, res, next) => {
+  res.set({
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'SAMEORIGIN',
+    'Referrer-Policy': 'strict-origin-when-cross-origin'
+  });
+  next();
+});
+
 // https://stackoverflow.com/questions/10348906/how-to-know-if-a-request-is-http-or-https-in-node-js
 app.enable('trust proxy');
 app.use(hostnameRedirection);


### PR DESCRIPTION
No security response headers were set on any route. This adds a small middleware in `app.js` that applies three baseline headers to every response.

## Problem

Without `X-Content-Type-Options`, browsers may MIME-sniff response bodies and execute content as a different type than declared. Without `X-Frame-Options`, any external site can embed qbreader pages in an iframe (clickjacking). Without `Referrer-Policy`, the full URL — including any query parameters — leaks to third-party origins via the `Referer` header.

## Changes

- Adds an inline middleware before routing that sets:
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: SAMEORIGIN`
  - `Referrer-Policy: strict-origin-when-cross-origin`

## Risk & testing

Configuration-only, no logic changes. CSP is intentionally omitted to avoid breaking existing inline scripts and styles; HSTS is omitted since HTTPS is already enforced by the existing `httpsEnforcement` middleware. No new dependencies. `semistandard` and `node --check` pass.