### PR TITLE
security: rate-limit POST /api/report-question to 30 requests/hour per IP

### DIFF
--- a/routes/api/report-question.js
+++ b/routes/api/report-question.js
@@ -2,8 +2,15 @@ import { ObjectId } from 'mongodb';
 import reportQuestion from '../../database/qbreader/report-question.js';
 
 import { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 
 const router = Router();
+router.use(rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 30, // Limit each IP to 30 requests per window
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false // Disable the `X-RateLimit-*` headers
+}));
 
 router.post('/', async (req, res) => {
   let _id;


### PR DESCRIPTION
`POST /api/report-question` had no rate limiting, making it trivial to flood the database with spurious reports.

## Problem

`routes/api/report-question.js` accepted an unlimited number of POST requests per IP. An automated client could generate thousands of bogus reports at no cost, polluting the moderation queue and adding unbounded write load to the database.

## Changes

- Adds `express-rate-limit` (already a project dependency) to `routes/api/report-question.js`.
- Limits each IP to 30 requests per hour; uses `standardHeaders: true` and `legacyHeaders: false`, matching the pattern already used in `routes/auth/index.js`.

## Risk & testing

Rate limiting is applied at the router level before the handler, so legitimate users are unaffected at normal usage volumes. No new dependencies introduced. `semistandard` and `node --check` pass.