### PR TITLE
perf: cache leaderboard aggregation result for 5 minutes

### DIFF
--- a/database/account-info/leaderboard.js
+++ b/database/account-info/leaderboard.js
@@ -1,7 +1,15 @@
 import { perTossupData, perBonusData } from '../../database/qbreader/collections.js';
 import mergeTwoSortedArrays from '../../server/merge-two-sorted-arrays.js';
 
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+let cachedOverall = null;
+let cachedAt = 0;
+
 export default async function leaderboard (limit) {
+  if (cachedOverall && Date.now() - cachedAt < CACHE_TTL) {
+    return cachedOverall.slice(0, limit);
+  }
+
   const tossupLeaderboard = await helper('tossup');
   const bonusLeaderboard = await helper('bonus');
   const overall = mergeTwoSortedArrays(
@@ -12,6 +20,8 @@ export default async function leaderboard (limit) {
   );
   // sort from most to least
   overall.sort((a, b) => b.total - a.total);
+  cachedOverall = overall;
+  cachedAt = Date.now();
   return overall.slice(0, limit);
 }
 


### PR DESCRIPTION
The leaderboard endpoint ran two full-collection `$unwind` aggregations on every request. Since the leaderboard changes infrequently, this is wasteful. This PR adds a 5-minute in-process cache in `database/account-info/leaderboard.js` so repeated calls — including all `limit` variants — share a single computed result.

## Problem
`leaderboard()` in `database/account-info/leaderboard.js` invokes two `$unwind` aggregation pipelines on every HTTP request with no caching. Under any moderate load the leaderboard endpoint becomes a repeated full-collection scan.

## Changes
- Adds two module-level variables (`cachedOverall`, `cachedAt`) and a `CACHE_TTL` constant (5 minutes).
- Returns the cached slice early if the cache is still fresh; recomputes and repopulates on expiry.

## Risk & testing
No new dependencies. The cache is module-scoped so it resets on server restart — this matches expected behavior. The 5-minute TTL is consistent with how infrequently leaderboard standings change. `semistandard` and `node --check` pass.
