### PR TITLE
security: add 7-day expiry to session JWTs

### DIFF
--- a/server/authentication.js
+++ b/server/authentication.js
@@ -59,7 +59,7 @@ export function checkToken (username, token, checkEmailVerification = false) {
  * @returns A JWT token.
  */
 export function generateToken (username, verifiedEmail = false) {
-  return sign({ username, verifiedEmail }, secret);
+  return sign({ username, verifiedEmail }, secret, { expiresIn: '7d' });
 }
 
 /**


### PR DESCRIPTION
Session JWTs were signed with no `exp` claim, meaning a stolen or leaked token remained valid indefinitely. This PR adds a 7-day expiry to tokens issued by `generateToken`, aligned with the existing `COOKIE_MAX_AGE` constant in `server/constants.js`.

## Problem
In `server/authentication.js`, `generateToken` called `sign({ username, verifiedEmail }, secret)` with no options object, producing tokens that never expire. A compromised token granted permanent account access regardless of when the theft occurred.

## Changes
- Passes `{ expiresIn: '7d' }` as the third argument to `sign()` in `generateToken`.

## Risk & testing
The `checkToken` verification path uses `jsonwebtoken`'s `verify()` with a callback that returns `false` on any error, including `TokenExpiredError` — expired tokens are rejected with no failure-open path. Existing tokens without an `exp` claim continue to work until their session cookie expires naturally; only newly issued tokens carry the expiry. The password-reset token path (which uses its own 15-minute timestamp logic) is untouched. `semistandard` and `node --check` pass.
