### PR TITLE
security: escape answer field in geoword admin compare view

### DIFF
--- a/client/admin/geoword/compare.js
+++ b/client/admin/geoword/compare.js
@@ -126,7 +126,7 @@ document.getElementById('form').addEventListener('submit', event => {
                         <div><b>Given answer:</b> ${escapeHTML(myBuzz.givenAnswer)}</div>
                     </div>
                     <div class="col-6">
-                        <div><b>Answer:</b> ${removeParentheses(myBuzz.answer)}</div>
+                        <div><b>Answer:</b> ${escapeHTML(removeParentheses(myBuzz.answer))}</div>
                         <div><b>Celerity:</b> ${(opponentBuzz.celerity ?? 0.0).toFixed(3)}</div>
                         <div><b>Points:</b> ${opponentBuzz.points}</div>
                         <div><b>Given answer:</b> ${escapeHTML(opponentBuzz.givenAnswer)}</div>


### PR DESCRIPTION
The canonical answer field in the geoword comparison view was interpolated directly into an innerHTML template literal without escaping, allowing a crafted answer string to inject arbitrary HTML and execute JavaScript when an admin views the page (stored XSS).

## Problem
In `client/admin/geoword/compare.js` at the answer display line, `myBuzz.answer` was passed through `removeParentheses` and then inserted raw into the template:

```js
<div><b>Answer:</b> ${removeParentheses(myBuzz.answer)}</div>
```

The `escapeHTML` utility was already imported and applied consistently to every other user-supplied field in the same file (`givenAnswer`, etc.), but was missing here.

## Changes
- Wraps the interpolation as `escapeHTML(removeParentheses(myBuzz.answer))`, using the utility already in scope.

## Risk & testing
Single-line change; no new imports or dependencies. `escapeHTML` plain-escapes text — it does not attempt to sanitize markup — which is the correct treatment for a plain-text answer field. Behavior is identical for answers containing no HTML special characters. `semistandard` and `node --check` pass.
