### PR TITLE
ux: soften .text-highlight background in night mode

### DIFF
--- a/scss/themes/night.scss
+++ b/scss/themes/night.scss
@@ -66,6 +66,11 @@ $form-switch-checked-bg-image-night: url("data:image/svg+xml,<svg xmlns='http://
         background: linear-gradient(#444, #333);
     }
 
+    .text-highlight {
+        background-color: rgba(248, 255, 0, 0.35);
+        color: inherit;
+    }
+
     // bootstrap
 
     @each $color, $value in $theme-colors-night {


### PR DESCRIPTION
The solid bright-yellow `.text-highlight` background was visually jarring in night mode, creating a harsh contrast against the dark surface. This PR adds a night-mode override that uses a translucent amber so highlighted query terms remain clearly visible without overwhelming the page.

## Problem
In night mode, `.text-highlight` rendered with the same fully-opaque `#f8ff00` background defined for light mode. Against a dark background this produced an uncomfortably bright flash of color that hurt readability rather than aiding it.

## Changes
- Adds a `.text-highlight` override inside the `@include color-mode(night, true)` block in `scss/themes/night.scss`, setting `background-color: rgba(248, 255, 0, 0.35)` and `color: inherit`.

## Risk & testing
Follows the existing pattern used throughout `scss/themes/night.scss` for night-mode overrides. The light-mode rule in `custom.scss` is untouched. CSS-only change with no JavaScript impact.
