### PR TITLE
feat: add /health endpoint for platform health checks

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -16,6 +16,8 @@ router.get('/*.scss', (req, res) => res.sendFile(req.url, { root: './scss' }));
 
 router.use(redirectsRouter);
 
+router.get('/health', (req, res) => res.sendStatus(200));
+
 /**
  * Routes:
  */


### PR DESCRIPTION
Adds a `/health` GET endpoint that returns HTTP 200 immediately, giving platform health checkers (Heroku, uptime monitors, load balancers) a fast, reliable signal that the process is alive.

## Problem
The server had no dedicated health route. Health checks from Heroku or other infrastructure would hit a full application route, which may perform database work or be gated behind heavier middleware. During DB reconnect delays or cold starts, those checks could fail or time out, causing unnecessary restarts.

## Changes
- Adds `router.get('/health', (req, res) => res.sendStatus(200))` in `routes/index.js`, registered before the heavier sub-routers so it responds as early as possible.

## Risk & testing
The route is a single line with no side effects and no database access. It cannot break any existing route because `/health` was previously unhandled. Low risk; `node --check` passes.
