### PR TITLE
a11y: make database action links keyboard-operable

### DIFF
--- a/client/db/index.jsx
+++ b/client/db/index.jsx
@@ -371,9 +371,9 @@ function QueryForm () {
             </div>
             <div className='float-end'>
               <b>Download this page:</b>
-              <a className='ms-2 clickable' onClick={() => { downloadQuestionsAsText({ tossups, bonuses }); }}>TXT</a>
-              <a className='ms-2 clickable' onClick={() => { downloadTossupsAsCSV(tossups); downloadBonusesAsCSV(bonuses); }}>CSV</a>
-              <a className='ms-2 clickable' onClick={() => { downloadQuestionsAsJSON(tossups, bonuses); }}>JSON</a>
+              <a className='ms-2 clickable' role='button' tabIndex={0} onClick={() => { downloadQuestionsAsText({ tossups, bonuses }); }} onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); downloadQuestionsAsText({ tossups, bonuses }); } }}>TXT</a>
+              <a className='ms-2 clickable' role='button' tabIndex={0} onClick={() => { downloadTossupsAsCSV(tossups); downloadBonusesAsCSV(bonuses); }} onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); downloadTossupsAsCSV(tossups); downloadBonusesAsCSV(bonuses); } }}>CSV</a>
+              <a className='ms-2 clickable' role='button' tabIndex={0} onClick={() => { downloadQuestionsAsJSON(tossups, bonuses); }} onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); downloadQuestionsAsJSON(tossups, bonuses); } }}>JSON</a>
             </div>
           </div>
         </div>
@@ -388,7 +388,7 @@ function QueryForm () {
           ? <div className='float-row mb-3'>
             <span className='text-muted float-start'>Showing {tossups.length} of {tossupCount} results ({queryTime} seconds)</span>&nbsp;
             <span className='text-muted float-end'>
-              <a className='clickable' onClick={() => window.scrollTo({ top: document.getElementById('bonuses').offsetTop, behavior: 'smooth' })}>
+              <a className='clickable' role='button' tabIndex={0} onClick={() => window.scrollTo({ top: document.getElementById('bonuses').offsetTop, behavior: 'smooth' })} onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); window.scrollTo({ top: document.getElementById('bonuses').offsetTop, behavior: 'smooth' }); } }}>
                 Jump to bonuses
               </a>
             </span>
@@ -447,7 +447,7 @@ function QueryForm () {
           ? <div className='float-row mb-3'>
             <span className='text-muted float-start'>Showing {bonuses.length} of {bonusCount} results ({queryTime} seconds)</span>&nbsp;
             <span className='text-muted float-end'>
-              <a className='clickable' onClick={() => window.scrollTo({ top: document.getElementById('tossups').offsetTop, behavior: 'smooth' })}>
+              <a className='clickable' role='button' tabIndex={0} onClick={() => window.scrollTo({ top: document.getElementById('tossups').offsetTop, behavior: 'smooth' })} onKeyDown={event => { if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); window.scrollTo({ top: document.getElementById('tossups').offsetTop, behavior: 'smooth' }); } }}>
                 Jump to tossups
               </a>
             </span>


### PR DESCRIPTION
The download (TXT / CSV / JSON) and section-jump links in `client/db/index.jsx` were `<a>` elements without an `href`, so they were invisible to keyboard navigation. This PR makes all five interactive without changing their appearance or click behavior.

## Problem
In `client/db/index.jsx`, five `<a class="... clickable">` elements relied solely on `onClick` handlers with no `href`. Anchor elements without `href` are excluded from the tab order, so keyboard users could not download results or jump between the tossup and bonus sections.

## Changes
- Adds `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler (activating on Enter and Space) to each of the five affected links: the TXT, CSV, and JSON download links and the "Jump to bonuses" / "Jump to tossups" scroll links.
- Existing `onClick` handlers and the `clickable` CSS class are preserved as-is; visual appearance is unchanged.

## Risk & testing
The change is purely additive — no existing logic is altered. The `onKeyDown` guard checks `event.key === 'Enter' || event.key === ' '` and calls `event.preventDefault()` before the action to avoid page-scroll on Space. `semistandard` and `node --check` pass.
