### PR TITLE
fix: reject malformed email addresses at signup

### DIFF
--- a/routes/auth/signup.js
+++ b/routes/auth/signup.js
@@ -1,7 +1,7 @@
 import { COOKIE_MAX_AGE } from '../../server/constants.js';
 import getUser from '../../database/account-info/get-user.js';
 import createUser from '../../database/account-info/create-user.js';
-import { generateToken, saltAndHashPassword, sendVerificationEmail, validateUsername } from '../../server/authentication.js';
+import { generateToken, saltAndHashPassword, sendVerificationEmail, validateEmail, validateUsername } from '../../server/authentication.js';
 
 import { Router } from 'express';
 
@@ -30,8 +30,13 @@ router.post('/', async (req, res) => {
   req.session.token = generateToken(username);
   req.session.expires = expires;
 
-  const password = saltAndHashPassword(req.body.password);
   const email = req.body.email;
+  if (email && !validateEmail(email)) {
+    res.sendStatus(400);
+    return;
+  }
+
+  const password = saltAndHashPassword(req.body.password);
   await createUser(username, password, email);
   sendVerificationEmail(username);
   // console.log(`/api/auth: SIGNUP: User ${username} successfully signed up.`);

--- a/routes/auth/signup.js
+++ b/routes/auth/signup.js
@@ -32,8 +32,7 @@ router.post('/', async (req, res) => {
 
   const email = req.body.email;
   if (email && !validateEmail(email)) {
-    res.sendStatus(400);
-    return;
+    return res.sendStatus(400);
   }
 
   const password = saltAndHashPassword(req.body.password);

--- a/server/authentication.js
+++ b/server/authentication.js
@@ -135,6 +135,15 @@ export function updatePassword (username, newPassword) {
 
 /**
  *
+ * @param {string} email
+ * @returns {boolean} True if the email is valid, and false otherwise.
+ */
+export function validateEmail (email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+/**
+ *
  * @param {string} username
  * @returns {boolean} True if the username is valid, and false otherwise.
  */


### PR DESCRIPTION
The signup route stored any string as an email address without validating its format. This adds a lightweight format check so obviously malformed addresses are rejected before they reach the database.

## Problem
In `routes/auth/signup.js`, `req.body.email` was passed directly to `createUser` with no validation. A malformed email written to the database would cause silent failures downstream — password reset and email verification would silently no-op because the address is unparseable by the mail transport.

## Changes
- Adds `validateEmail(email)` to `server/authentication.js`: a permissive `user@domain.tld` regex check (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`) that returns `false` on obvious format errors.
- In `routes/auth/signup.js`, applies the check before `saltAndHashPassword` and `createUser`. The guard fires **only when an email is provided** — absent or empty-string emails pass through unchanged, so accounts that sign up without an email are unaffected.
- Returns HTTP 400 on an invalid email so the client can surface a useful error.

## Risk & testing
No existing signup flow is broken: the validation is conditional on a non-empty email value. The regex is intentionally permissive to avoid false rejections of valid but unusual addresses. Mirrors the existing `validateUsername` pattern in the same file. `node --check` passes.
