### PR TITLE
fix: drop all over-limit messages and clear rate-limit flag on recovery

### DIFF
--- a/server/multiplayer/ServerMultiplayerRoomMixin.js
+++ b/server/multiplayer/ServerMultiplayerRoomMixin.js
@@ -120,11 +120,16 @@ const ServerMultiplayerRoomMixin = (RoomClass) => class extends RoomClass {
     }
 
     socket.on('message', message => {
-      if (this.rateLimiter(socket) && !this.rateLimitExceeded.has(username)) {
-        console.log(`Rate limit exceeded for ${username} in room ${this.name}`);
-        this.rateLimitExceeded.add(username);
+      if (this.rateLimiter(socket)) {
+        // Still over the limit: always drop the message, but only log once per burst.
+        if (!this.rateLimitExceeded.has(username)) {
+          console.log(`Rate limit exceeded for ${username} in room ${this.name}`);
+          this.rateLimitExceeded.add(username);
+        }
         return;
       }
+      // Back under the limit: clear the flag so the user recovers.
+      this.rateLimitExceeded.delete(username);
 
       try {
         message = JSON.parse(message);


### PR DESCRIPTION
Fixes two bugs in the multiplayer rate-limiter: flagged users' subsequent over-limit messages were no longer being dropped, and the flag was never cleared even after a user returned under the limit.

## Problem
In `server/multiplayer/ServerMultiplayerRoomMixin.js` (around line 120), the guard condition was:

```js
if (this.rateLimiter(socket) && !this.rateLimitExceeded.has(username)) {
  this.rateLimitExceeded.add(username);
  return;
}
```

This had two defects:

1. **Messages not dropped after the first burst**: Once `username` was in `rateLimitExceeded`, the condition `!this.rateLimitExceeded.has(username)` became `false`, so the entire guard evaluated to `false` and the `return` was never reached. Subsequent over-limit messages from that user were processed rather than dropped.
2. **Flag never cleared**: `rateLimitExceeded` was only ever added to, never cleaned up. A user who briefly exceeded the limit and then went quiet remained flagged for the entire room lifetime, affecting future legitimate messages after a cooldown.

## Changes
- Restructures the guard to call `return` unconditionally whenever `this.rateLimiter(socket)` is truthy, dropping every over-limit message.
- Uses `rateLimitExceeded` only to suppress duplicate log lines within a burst (log once, not once per message).
- Calls `this.rateLimitExceeded.delete(username)` on the non-rate-limited path so a user recovers automatically once their message rate falls back under the limit.

## Risk & testing
Logic-only change; no new dependencies. The anti-spam behavior is strictly strengthened — legitimate messages in a new interval are unaffected. Verified by reading the `rateLimiter` contract: it returns truthy while the socket is over limit and falsy once the interval resets. `node --check` passes.
