### PR TITLE
security: migrate password hashing from triple-SHA-256 to bcrypt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "qbreader",
             "version": "26.04",
             "dependencies": {
+                "bcryptjs": "^2.4.3",
                 "bootstrap": "^5.3.8",
                 "bootstrap-icons": "^1.13.1",
                 "cookie-session": "^2.0.0",
@@ -1671,6 +1672,12 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+            "license": "MIT"
         },
         "node_modules/bidi-js": {
             "version": "1.0.3",
@@ -8360,6 +8367,11 @@
                     "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
                 }
             }
+        },
+        "bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
         },
         "bidi-js": {
             "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "webpack": "webpack --config webpack.config.js"
     },
     "dependencies": {
+        "bcryptjs": "^2.4.3",
         "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
         "cookie-session": "^2.0.0",

--- a/routes/auth/signup.js
+++ b/routes/auth/signup.js
@@ -30,7 +30,7 @@ router.post('/', async (req, res) => {
   req.session.token = generateToken(username);
   req.session.expires = expires;
 
-  const password = saltAndHashPassword(req.body.password);
+  const password = await saltAndHashPassword(req.body.password);
   const email = req.body.email;
   await createUser(username, password, email);
   sendVerificationEmail(username);

--- a/server/authentication.js
+++ b/server/authentication.js
@@ -6,10 +6,13 @@ import getUserId from '../database/account-info/get-user-id.js';
 import updateUser from '../database/account-info/update-user.js';
 import verifyEmail from '../database/account-info/verify-email.js';
 
+import bcrypt from 'bcryptjs';
 import { createHash } from 'crypto';
 import jsonwebtoken from 'jsonwebtoken';
 import { ObjectId } from 'mongodb';
 const { sign, verify } = jsonwebtoken;
+
+const BCRYPT_ROUNDS = 12;
 
 const baseURL = process.env.BASE_URL ?? (process.env.NODE_ENV === 'production' ? 'https://www.qbreader.org' : 'http://localhost:3000');
 
@@ -32,7 +35,23 @@ const activeResetPasswordTokens = {};
  * @returns {Promise<Boolean>}
  */
 export async function checkPassword (username, password) {
-  return await getUserField(username, 'password') === saltAndHashPassword(password);
+  const stored = await getUserField(username, 'password');
+  if (!stored) {
+    return false;
+  }
+
+  // bcrypt hashes always start with `$2`; legacy base64 hashes never do.
+  if (stored.startsWith('$2')) {
+    return await bcrypt.compare(password, stored);
+  }
+
+  // Legacy triple-SHA256 hash: verify, then transparently upgrade to bcrypt.
+  if (stored === legacyHashPassword(password)) {
+    await updatePassword(username, password);
+    return true;
+  }
+
+  return false;
 }
 
 /**
@@ -63,11 +82,21 @@ export function generateToken (username, verifiedEmail = false) {
 }
 
 /**
- *
+ * Hashes a plaintext password using bcrypt (per-hash salt, configurable work factor).
  * @param {String} password
- * @returns Base64 encoded hashed password.
+ * @returns {Promise<String>} A bcrypt hash (60 chars, starts with `$2`).
  */
-export function saltAndHashPassword (password) {
+export async function saltAndHashPassword (password) {
+  return await bcrypt.hash(password, BCRYPT_ROUNDS);
+}
+
+/**
+ * Legacy triple-SHA256 hash with a single global salt. Retained only to verify
+ * pre-migration passwords so they can be transparently upgraded to bcrypt.
+ * @param {String} password
+ * @returns {String} Base64 encoded hashed password.
+ */
+function legacyHashPassword (password) {
   password = salt + password + salt;
   const hash = createHash('sha256').update(password).digest('base64');
   const hash2 = createHash('sha256').update(hash).digest('base64');
@@ -129,8 +158,8 @@ export async function sendVerificationEmail (username) {
   return true;
 }
 
-export function updatePassword (username, newPassword) {
-  return updateUser(username, { password: saltAndHashPassword(newPassword) });
+export async function updatePassword (username, newPassword) {
+  return await updateUser(username, { password: await saltAndHashPassword(newPassword) });
 }
 
 /**


### PR DESCRIPTION
Account passwords were stored as a triple-SHA256 digest using a single global salt (`server/authentication.js:35`). SHA-256 is a fast, general-purpose hash with no per-user salt and no tunable work factor, making the stored credentials cheap to crack at scale on GPU hardware if the database is ever exposed.

## Problem

`saltAndHashPassword` applied `sha256(sha256(sha256(salt + password + salt)))` and stored the base64 result. A single compromised global salt means every password hash can be attacked in parallel with identical setup, and fast hashing hardware significantly reduces the effort required.

## Changes

- `server/authentication.js` — `saltAndHashPassword` is now `async` and delegates to `bcrypt.hash` at cost factor 12. The old triple-SHA-256 body is preserved as a private `legacyHashPassword` helper. `checkPassword` distinguishes formats by prefix: bcrypt hashes always begin with `$2`; legacy base64 digests never do. A matching legacy hash is re-hashed to bcrypt and written back transparently. `updatePassword` is now `async`.
- `routes/auth/signup.js` — awaits the now-async `saltAndHashPassword`.
- `package.json` / `package-lock.json` — add `bcryptjs@^2.4.3`.

`bcryptjs` (pure JS) was chosen to avoid native build steps; the native `bcrypt` package can be swapped in later without changing call sites. Callers in `routes/auth/login.js`, `routes/auth/edit-password.js`, and `routes/auth/reset-password.js` already awaited `checkPassword`/`updatePassword` and required no changes.

## Risk & testing

**Existing users are not locked out.** `checkPassword` accepts the legacy triple-SHA-256 hash and on a successful match immediately re-hashes to bcrypt and writes it back, so accounts roll over silently on next login. Once every row in the database has a `$2`-prefixed hash, `legacyHashPassword` can be deleted.

The soft migration path was verified by inspection: the prefix check is correct, `updatePassword` is awaited inside the upgrade branch, and `signup.js` correctly awaits the now-async `saltAndHashPassword`. No live database is required to test the hashing logic itself.