### PR TITLE
Link frequency list answers to prefilled database search

### DIFF
--- a/client/db/frequency-list/subcategory.html
+++ b/client/db/frequency-list/subcategory.html
@@ -23,7 +23,7 @@
                 aria-label="Download frequency list as TXT">TXT</a><a class="ms-2 clickable" id="download-frequency-list-csv"
                 role="button" tabindex="0" aria-label="Download frequency list as CSV">CSV</a>
         </p>
-        <form class="row mb-3" id="form">
+        <form class="row" id="form">
             <div class="col-6 col-md-4 mb-3">
                 <label class="form-label" for="difficulty-dropdown-root">Choose a difficulty level:</label>
                 <div id="difficulty-dropdown-root"></div>
@@ -55,6 +55,7 @@
                 </div>
             </div>
         </form>
+        <p>Click on an answer to search for it in the database:</p>
         <table class="table table-hover">
             <thead>
                 <tr>

--- a/client/db/frequency-list/subcategory.jsx
+++ b/client/db/frequency-list/subcategory.jsx
@@ -67,11 +67,8 @@ function createAnswerLink (answer, difficulties, minYear, maxYear, questionType)
     if (!isCategory) {
       params.categories = isAlternate ? ALTERNATE_SUBCATEGORY_TO_CATEGORY[subcategory] : SUBCATEGORY_TO_CATEGORY[subcategory];
     }
-    // minYear/maxYear must always be sent explicitly: /api/query's implicit
-    // defaults (MIN_YEAR/MAX_YEAR) differ from the frequency list's slider
-    // defaults (DEFAULT_MIN_YEAR/DEFAULT_MAX_YEAR), so letting filterParams
-    // strip them here (as it does for the frequency list's own fetch) would
-    // widen the db search beyond what the frequency list actually reflects.
+    // minYear/maxYear must be sent explicitly, since otherwise filterParams
+    // would incorrectly strip them here since it uses different defaults
     const filteredParams = filterParams(params);
     filteredParams.minYear = minYear;
     filteredParams.maxYear = maxYear;

--- a/client/db/frequency-list/subcategory.jsx
+++ b/client/db/frequency-list/subcategory.jsx
@@ -62,14 +62,20 @@ function createAnswerLink (answer, difficulties, minYear, maxYear, questionType)
       searchType: 'exactAnswer',
       questionType,
       difficulties,
-      minYear,
-      maxYear,
       [isCategory ? 'categories' : isAlternate ? 'alternateSubcategories' : 'subcategories']: subcategory
     };
     if (!isCategory) {
       params.categories = isAlternate ? ALTERNATE_SUBCATEGORY_TO_CATEGORY[subcategory] : SUBCATEGORY_TO_CATEGORY[subcategory];
     }
-    window.location.href = '/db/?' + new URLSearchParams(filterParams(params));
+    // minYear/maxYear must always be sent explicitly: /api/query's implicit
+    // defaults (MIN_YEAR/MAX_YEAR) differ from the frequency list's slider
+    // defaults (DEFAULT_MIN_YEAR/DEFAULT_MAX_YEAR), so letting filterParams
+    // strip them here (as it does for the frequency list's own fetch) would
+    // widen the db search beyond what the frequency list actually reflects.
+    const filteredParams = filterParams(params);
+    filteredParams.minYear = minYear;
+    filteredParams.maxYear = maxYear;
+    window.location.href = '/db/?' + new URLSearchParams(filteredParams);
   };
 
   link.addEventListener('click', navigate);

--- a/client/db/frequency-list/subcategory.jsx
+++ b/client/db/frequency-list/subcategory.jsx
@@ -48,6 +48,37 @@ function formatFrequencyListAsCSV () {
   return csv;
 }
 
+function createAnswerLink (answer, difficulties, minYear, maxYear, questionType) {
+  const link = document.createElement('a');
+  link.textContent = answer;
+  link.className = 'clickable text-body text-decoration-none';
+  link.role = 'button';
+  link.tabIndex = 0;
+
+  const navigate = () => {
+    const params = {
+      q: answer,
+      searchType: 'exactAnswer',
+      questionType,
+      difficulties,
+      minYear,
+      maxYear,
+      [isCategory ? 'categories' : isAlternate ? 'alternateSubcategories' : 'subcategories']: subcategory
+    };
+    window.location.href = '/db/?' + new URLSearchParams(filterParams(params));
+  };
+
+  link.addEventListener('click', navigate);
+  link.addEventListener('keydown', event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      navigate();
+    }
+  });
+
+  return link;
+}
+
 function updateFrequencyListDisplay (difficulties, limit, minYear, maxYear, questionType) {
   const table = document.getElementById('frequency-list');
   table.innerHTML = '';
@@ -74,7 +105,7 @@ function updateFrequencyListDisplay (difficulties, limit, minYear, maxYear, ques
       for (const [index, { answer, count }] of frequencyList.entries()) {
         const row = table.insertRow();
         row.insertCell().textContent = index + 1;
-        row.insertCell().textContent = answer;
+        row.insertCell().appendChild(createAnswerLink(answer, difficulties, minYear, maxYear, questionType));
         row.insertCell().textContent = count;
       }
 

--- a/client/db/frequency-list/subcategory.jsx
+++ b/client/db/frequency-list/subcategory.jsx
@@ -3,6 +3,7 @@ import { downloadAsFile } from '../../scripts/download.js';
 import { getDropdownValues } from '../../scripts/utilities/dropdown-checklist.js';
 import filterParams from '../../scripts/utilities/filter-params.js';
 import { DIFFICULTIES, DEFAULT_MIN_YEAR, DEFAULT_MAX_YEAR } from '../../../shared/constants.js';
+import { SUBCATEGORY_TO_CATEGORY, ALTERNATE_SUBCATEGORY_TO_CATEGORY } from '../../../shared/categories.js';
 import { setYear, addSliderEventListeners } from '../../play/year-slider.js';
 
 let difficulties = DIFFICULTIES;
@@ -65,6 +66,9 @@ function createAnswerLink (answer, difficulties, minYear, maxYear, questionType)
       maxYear,
       [isCategory ? 'categories' : isAlternate ? 'alternateSubcategories' : 'subcategories']: subcategory
     };
+    if (!isCategory) {
+      params.categories = isAlternate ? ALTERNATE_SUBCATEGORY_TO_CATEGORY[subcategory] : SUBCATEGORY_TO_CATEGORY[subcategory];
+    }
     window.location.href = '/db/?' + new URLSearchParams(filterParams(params));
   };
 

--- a/client/db/index.jsx
+++ b/client/db/index.jsx
@@ -119,7 +119,7 @@ function QueryForm () {
     return handlePaginationClick(event, value, 'bonus');
   }
 
-  function handleSubmit (event = null, randomize = false, paginationUpdate = false, replaceState = false) {
+  function handleSubmit (event = null, randomize = false, paginationUpdate = false) {
     const startTime = window.performance.now();
 
     event?.preventDefault();
@@ -210,12 +210,7 @@ function QueryForm () {
         const timeElapsed = ((endTime - startTime) / 1000).toFixed(2);
         setQueryTime(timeElapsed);
 
-        const historyState = { tossups, highlightedTossupArray, bonuses, highlightedBonusArray, timeElapsed, workingMaxReturnLength, randomize };
-        if (replaceState) {
-          window.history.replaceState(historyState, '', '?' + params);
-        } else {
-          window.history.pushState(historyState, '', '?' + params);
-        }
+        window.history.pushState({ tossups, highlightedTossupArray, bonuses, highlightedBonusArray, timeElapsed, workingMaxReturnLength, randomize }, '', '?' + params);
       })
       .catch(error => {
         console.error('Error:', error);
@@ -294,7 +289,7 @@ function QueryForm () {
     if (window.location.search !== '') {
       const difficulties = initialParams.get('difficulties')?.split(',')?.map(difficulty => parseInt(difficulty));
       if (difficulties) { setDropdownValues('difficulties', difficulties); }
-      handleSubmit(null, initialParams.get('randomize') === 'true', false, true);
+      handleSubmit(null, initialParams.get('randomize') === 'true');
     }
   }, []);
 

--- a/client/db/index.jsx
+++ b/client/db/index.jsx
@@ -119,7 +119,7 @@ function QueryForm () {
     return handlePaginationClick(event, value, 'bonus');
   }
 
-  function handleSubmit (event = null, randomize = false, paginationUpdate = false) {
+  function handleSubmit (event = null, randomize = false, paginationUpdate = false, replaceState = false) {
     const startTime = window.performance.now();
 
     event?.preventDefault();
@@ -210,7 +210,12 @@ function QueryForm () {
         const timeElapsed = ((endTime - startTime) / 1000).toFixed(2);
         setQueryTime(timeElapsed);
 
-        window.history.pushState({ tossups, highlightedTossupArray, bonuses, highlightedBonusArray, timeElapsed, workingMaxReturnLength, randomize }, '', '?' + params);
+        const historyState = { tossups, highlightedTossupArray, bonuses, highlightedBonusArray, timeElapsed, workingMaxReturnLength, randomize };
+        if (replaceState) {
+          window.history.replaceState(historyState, '', '?' + params);
+        } else {
+          window.history.pushState(historyState, '', '?' + params);
+        }
       })
       .catch(error => {
         console.error('Error:', error);
@@ -289,7 +294,7 @@ function QueryForm () {
     if (window.location.search !== '') {
       const difficulties = initialParams.get('difficulties')?.split(',')?.map(difficulty => parseInt(difficulty));
       if (difficulties) { setDropdownValues('difficulties', difficulties); }
-      handleSubmit(null, initialParams.get('randomize') === 'true');
+      handleSubmit(null, initialParams.get('randomize') === 'true', false, true);
     }
   }, []);
 


### PR DESCRIPTION
## Problem and Solution

Currently, the frequency list pages (`/db/frequency-list/...`) show answer/frequency pairs as plain text. To actually read a matching question, users have to manually re-enter the answerline, category/subcategory, question type, difficulty, and year range on the database search page. This PR makes each answer in the frequency list a link that jumps straight to the database search page with all of those fields pre-filled and the search already run.

Clicking an answer navigates to `/db/...` with `q`, `searchType=exactAnswer`, `questionType`, `difficulties`, `minYear`/`maxYear`, and the resolved category/subcategory/alternate-subcategory params, reusing the database page's existing support for linking via query string. Links are styled to look like plain text (no blue/purple color, no underline).

## Risks and Testing

In rare cases the linked search can show **fewer** result than the frequency list's count. This happens when two spelling variants of the same answer, differing only by hyphenation (e.g. "Jacques-Louis David" vs. "Jacques Louis David"), both exist in the database. `get-frequency-list.js` normalizes hyphens to spaces when grouping answers, so both variants count toward the same frequency total, but `/api/query`'s answer search does a literal regex match and won't match a variant it wasn't built from. This is a pre-existing discrepancy between the frequency-list aggregation and the query search logic. Fixing it would mean changing shared search-matching behavior in `routes/api/query.js`/`database/qbreader/get-query.js`, which is out of scope for this change.

Verified locally against the real MongoDB Database:
- Clicking an answer from category-wide, subcategory-scoped, and alternate-subcategory-scoped frequency lists all land on a correctly pre-filled, auto-run search.
- One click back from the search results returns to the originating frequency list.
- Category/subcategory checkboxes are correctly highlighted after navigating from a subcategory or alternate-subcategory frequency list.
- Result counts match the frequency list's reported count, except for the documented hyphenation edge case above.