### PR TITLE
fix broken sort algorithm

### DIFF
--- a/client/db/set-list/index.html
+++ b/client/db/set-list/index.html
@@ -18,12 +18,12 @@
         <table class="table table-hover">
             <thead>
                 <tr>
-                    <th scope="col">Set Name</th>
-                    <th scope="col">Difficulty</th>
-                    <th scope="col">Standard</th>
-                    <th scope="col"># of Packets</th>
-                    <th scope="col"># of Tossups</th>
-                    <th scope="col"># of Bonuses</th>
+                    <th scope="col" class="clickable" data-sort-key="setName">Set Name <i class="bi"></i></th>
+                    <th scope="col" class="clickable" data-sort-key="difficulty">Difficulty <i class="bi"></i></th>
+                    <th scope="col" class="clickable" data-sort-key="standard">Standard <i class="bi"></i></th>
+                    <th scope="col" class="clickable" data-sort-key="packetsCount"># of Packets <i class="bi"></i></th>
+                    <th scope="col" class="clickable" data-sort-key="tossupsCount"># of Tossups <i class="bi"></i></th>
+                    <th scope="col" class="clickable" data-sort-key="bonusesCount"># of Bonuses <i class="bi"></i></th>
                 </tr>
             </thead>
             <tbody class="table-group-divider" id="set-metadata-list"></tbody>

--- a/client/db/set-list/index.html
+++ b/client/db/set-list/index.html
@@ -18,12 +18,13 @@
         <table class="table table-hover">
             <thead>
                 <tr>
-                    <th scope="col" class="clickable">Set Name</th>
-                    <th scope="col" class="clickable">Difficulty</th>
-                    <th scope="col" class="clickable">Standard</th>
-                    <th scope="col" class="clickable"># of Packets</th>
-                    <th scope="col" class="clickable"># of Tossups</th>
-                    <th scope="col" class="clickable"># of Bonuses</th>
+                    <th scope="col" class="clickable" aria-sort="none">Set Name <span class="sort-indicator"></span></th>
+                    <th scope="col" class="clickable" aria-sort="none">Difficulty <span class="sort-indicator"></span></th>
+                    <th scope="col" class="clickable" aria-sort="none">Standard <span class="sort-indicator"></span></th>
+                    <!-- The count columns only become sortable once their counts arrive; see index.js -->
+                    <th scope="col" class="text-body-tertiary" aria-sort="none"># of Packets <span class="sort-indicator"></span></th>
+                    <th scope="col" class="text-body-tertiary" aria-sort="none"># of Tossups <span class="sort-indicator"></span></th>
+                    <th scope="col" class="text-body-tertiary" aria-sort="none"># of Bonuses <span class="sort-indicator"></span></th>
                 </tr>
             </thead>
             <tbody class="table-group-divider" id="set-metadata-list"></tbody>

--- a/client/db/set-list/index.html
+++ b/client/db/set-list/index.html
@@ -18,12 +18,12 @@
         <table class="table table-hover">
             <thead>
                 <tr>
-                    <th scope="col" class="clickable" data-sort-key="setName">Set Name <i class="bi"></i></th>
-                    <th scope="col" class="clickable" data-sort-key="difficulty">Difficulty <i class="bi"></i></th>
-                    <th scope="col" class="clickable" data-sort-key="standard">Standard <i class="bi"></i></th>
-                    <th scope="col" class="clickable" data-sort-key="packetsCount"># of Packets <i class="bi"></i></th>
-                    <th scope="col" class="clickable" data-sort-key="tossupsCount"># of Tossups <i class="bi"></i></th>
-                    <th scope="col" class="clickable" data-sort-key="bonusesCount"># of Bonuses <i class="bi"></i></th>
+                    <th scope="col" class="clickable">Set Name</th>
+                    <th scope="col" class="clickable">Difficulty</th>
+                    <th scope="col" class="clickable">Standard</th>
+                    <th scope="col" class="clickable"># of Packets</th>
+                    <th scope="col" class="clickable"># of Tossups</th>
+                    <th scope="col" class="clickable"># of Bonuses</th>
                 </tr>
             </thead>
             <tbody class="table-group-divider" id="set-metadata-list"></tbody>

--- a/client/db/set-list/index.js
+++ b/client/db/set-list/index.js
@@ -1,31 +1,82 @@
+let sets = [];
+let sortKey = null;
+let sortAscending = true;
+
+function renderTable () {
+  const table = document.getElementById('set-metadata-list');
+  table.textContent = '';
+  sets.forEach(({ _id, setName, difficulty, standard, packetsCount, tossupsCount, bonusesCount }) => {
+    const row = table.insertRow(-1);
+    const a = document.createElement('a');
+    a.href = `../set/?_id=${_id}`;
+    a.textContent = setName;
+    row.insertCell(-1).appendChild(a);
+    row.insertCell(-1).textContent = difficulty;
+    row.insertCell(-1).textContent = standard;
+    row.insertCell(-1).textContent = packetsCount ?? '-';
+    row.insertCell(-1).textContent = tossupsCount ?? '-';
+    row.insertCell(-1).textContent = bonusesCount ?? '-';
+  });
+}
+
+function updateSortIcons () {
+  document.querySelectorAll('th[data-sort-key]').forEach(th => {
+    const icon = th.querySelector('i.bi');
+    if (th.dataset.sortKey !== sortKey) {
+      icon.className = 'bi bi-arrow-down-up text-muted';
+    } else {
+      icon.className = sortAscending ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill';
+    }
+  });
+}
+
+function compareRows (a, b, key) {
+  const valueA = a[key];
+  const valueB = b[key];
+  if (valueA == null && valueB == null) return 0;
+  if (valueA == null) return -1;
+  if (valueB == null) return 1;
+  if (typeof valueA === 'string') return valueA.localeCompare(valueB);
+  if (valueA < valueB) return -1;
+  if (valueA > valueB) return 1;
+  return 0;
+}
+
+function sortByKey (key) {
+  sortAscending = sortKey === key ? !sortAscending : true;
+  sortKey = key;
+  sets.sort((a, b) => compareRows(a, b, key) * (sortAscending ? 1 : -1));
+  renderTable();
+  updateSortIcons();
+}
+
+document.querySelectorAll('th[data-sort-key]').forEach(th => {
+  th.addEventListener('click', () => sortByKey(th.dataset.sortKey));
+});
+updateSortIcons();
+
 await fetch('/api/set-list?' + new URLSearchParams({ expand: true }))
   .then(res => res.json())
   .then(({ setList }) => {
     document.getElementById('spinner').classList.add('d-none');
-    const table = document.getElementById('set-metadata-list');
-    setList.forEach(({ _id, setName, difficulty, standard }) => {
-      const row = table.insertRow(-1);
-      const a = document.createElement('a');
-      a.href = `../set/?_id=${_id}`;
-      a.textContent = setName;
-      row.insertCell(-1).appendChild(a);
-      row.insertCell(-1).textContent = difficulty;
-      row.insertCell(-1).textContent = standard;
-      row.insertCell(-1).textContent = '-';
-      row.insertCell(-1).textContent = '-';
-      row.insertCell(-1).textContent = '-';
-    });
+    sets = setList;
+    renderTable();
   });
 
 fetch('/api/set-list?' + new URLSearchParams({ expand: true, includeCounts: true }))
   .then(res => res.json())
   .then(({ setList }) => {
     document.getElementById('spinner').classList.add('d-none');
-    const table = document.getElementById('set-metadata-list');
-    const rows = table.rows;
-    for (let i = 0; i < setList.length; i++) {
-      rows[i].cells[3].textContent = setList[i].packetsCount;
-      rows[i].cells[4].textContent = setList[i].tossupsCount;
-      rows[i].cells[5].textContent = setList[i].bonusesCount;
+    const countsById = new Map(setList.map(set => [set._id, set]));
+    sets.forEach(set => {
+      const counts = countsById.get(set._id);
+      if (!counts) return;
+      set.packetsCount = counts.packetsCount;
+      set.tossupsCount = counts.tossupsCount;
+      set.bonusesCount = counts.bonusesCount;
+    });
+    if (['packetsCount', 'tossupsCount', 'bonusesCount'].includes(sortKey)) {
+      sets.sort((a, b) => compareRows(a, b, sortKey) * (sortAscending ? 1 : -1));
     }
+    renderTable();
   });

--- a/client/db/set-list/index.js
+++ b/client/db/set-list/index.js
@@ -1,16 +1,54 @@
 import sortTable from '../../scripts/utilities/tables.js';
 
 const isNumericColumn = [false, true, false, true, true, true];
+const COUNT_COLUMNS = [3, 4, 5];
+const COUNT_PLACEHOLDER = '-';
 
-document.querySelectorAll('th').forEach((th, index) => {
-  th.addEventListener('click', () => sortTable(index, isNumericColumn[index], 'set-metadata-list', 0, 0));
+const table = document.getElementById('set-metadata-list');
+const headerCells = Array.from(table.closest('table').querySelectorAll('thead th'));
+
+// The counts arrive from a second, much slower request. Until they do, their
+// cells hold placeholders, so sorting by them would silently do nothing.
+let countsLoaded = false;
+
+function isSortable (index) {
+  return countsLoaded || !COUNT_COLUMNS.includes(index);
+}
+
+function updateSortIndicators () {
+  const sortedColumn = table.dataset.sortColumn;
+  const ascending = table.dataset.sortAscending === 'true';
+  headerCells.forEach((th, index) => {
+    const indicator = th.querySelector('.sort-indicator');
+    if (String(index) === sortedColumn) {
+      th.setAttribute('aria-sort', ascending ? 'ascending' : 'descending');
+      indicator.className = `sort-indicator bi bi-caret-${ascending ? 'up' : 'down'}-fill`;
+    } else {
+      th.setAttribute('aria-sort', 'none');
+      indicator.className = 'sort-indicator';
+    }
+  });
+}
+
+function enableCountSorting () {
+  countsLoaded = true;
+  for (const index of COUNT_COLUMNS) {
+    headerCells[index].classList.replace('text-body-tertiary', 'clickable');
+  }
+}
+
+headerCells.forEach((th, index) => {
+  th.addEventListener('click', () => {
+    if (!isSortable(index)) { return; }
+    sortTable(index, isNumericColumn[index], 'set-metadata-list', 0, 0);
+    updateSortIndicators();
+  });
 });
 
 await fetch('/api/set-list?' + new URLSearchParams({ expand: true }))
   .then(res => res.json())
   .then(({ setList }) => {
     document.getElementById('spinner').classList.add('d-none');
-    const table = document.getElementById('set-metadata-list');
     setList.forEach(({ _id, setName, difficulty, standard }) => {
       const row = table.insertRow(-1);
       row.dataset.setId = _id;
@@ -20,9 +58,9 @@ await fetch('/api/set-list?' + new URLSearchParams({ expand: true }))
       row.insertCell(-1).appendChild(a);
       row.insertCell(-1).textContent = difficulty;
       row.insertCell(-1).textContent = standard;
-      row.insertCell(-1).textContent = '-';
-      row.insertCell(-1).textContent = '-';
-      row.insertCell(-1).textContent = '-';
+      row.insertCell(-1).textContent = COUNT_PLACEHOLDER;
+      row.insertCell(-1).textContent = COUNT_PLACEHOLDER;
+      row.insertCell(-1).textContent = COUNT_PLACEHOLDER;
     });
   });
 
@@ -30,7 +68,6 @@ fetch('/api/set-list?' + new URLSearchParams({ expand: true, includeCounts: true
   .then(res => res.json())
   .then(({ setList }) => {
     document.getElementById('spinner').classList.add('d-none');
-    const table = document.getElementById('set-metadata-list');
     // Look rows up by set id instead of index: the user may have sorted the
     // table while this request was in flight, which reorders the rows.
     const rowsBySetId = new Map(Array.from(table.rows).map(row => [row.dataset.setId, row]));
@@ -41,4 +78,10 @@ fetch('/api/set-list?' + new URLSearchParams({ expand: true, includeCounts: true
       row.cells[4].textContent = tossupsCount;
       row.cells[5].textContent = bonusesCount;
     }
+    enableCountSorting();
+  })
+  .catch(error => {
+    // Leave the placeholders and the columns unsortable rather than offering a
+    // sort over data that never arrived.
+    console.error('Could not load set counts:', error);
   });

--- a/client/db/set-list/index.js
+++ b/client/db/set-list/index.js
@@ -1,82 +1,44 @@
-let sets = [];
-let sortKey = null;
-let sortAscending = true;
+import sortTable from '../../scripts/utilities/tables.js';
 
-function renderTable () {
-  const table = document.getElementById('set-metadata-list');
-  table.textContent = '';
-  sets.forEach(({ _id, setName, difficulty, standard, packetsCount, tossupsCount, bonusesCount }) => {
-    const row = table.insertRow(-1);
-    const a = document.createElement('a');
-    a.href = `../set/?_id=${_id}`;
-    a.textContent = setName;
-    row.insertCell(-1).appendChild(a);
-    row.insertCell(-1).textContent = difficulty;
-    row.insertCell(-1).textContent = standard;
-    row.insertCell(-1).textContent = packetsCount ?? '-';
-    row.insertCell(-1).textContent = tossupsCount ?? '-';
-    row.insertCell(-1).textContent = bonusesCount ?? '-';
-  });
-}
+const isNumericColumn = [false, true, false, true, true, true];
 
-function updateSortIcons () {
-  document.querySelectorAll('th[data-sort-key]').forEach(th => {
-    const icon = th.querySelector('i.bi');
-    if (th.dataset.sortKey !== sortKey) {
-      icon.className = 'bi bi-arrow-down-up text-muted';
-    } else {
-      icon.className = sortAscending ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill';
-    }
-  });
-}
-
-function compareRows (a, b, key) {
-  const valueA = a[key];
-  const valueB = b[key];
-  if (valueA == null && valueB == null) return 0;
-  if (valueA == null) return -1;
-  if (valueB == null) return 1;
-  if (typeof valueA === 'string') return valueA.localeCompare(valueB);
-  if (valueA < valueB) return -1;
-  if (valueA > valueB) return 1;
-  return 0;
-}
-
-function sortByKey (key) {
-  sortAscending = sortKey === key ? !sortAscending : true;
-  sortKey = key;
-  sets.sort((a, b) => compareRows(a, b, key) * (sortAscending ? 1 : -1));
-  renderTable();
-  updateSortIcons();
-}
-
-document.querySelectorAll('th[data-sort-key]').forEach(th => {
-  th.addEventListener('click', () => sortByKey(th.dataset.sortKey));
+document.querySelectorAll('th').forEach((th, index) => {
+  th.addEventListener('click', () => sortTable(index, isNumericColumn[index], 'set-metadata-list', 0, 0));
 });
-updateSortIcons();
 
 await fetch('/api/set-list?' + new URLSearchParams({ expand: true }))
   .then(res => res.json())
   .then(({ setList }) => {
     document.getElementById('spinner').classList.add('d-none');
-    sets = setList;
-    renderTable();
+    const table = document.getElementById('set-metadata-list');
+    setList.forEach(({ _id, setName, difficulty, standard }) => {
+      const row = table.insertRow(-1);
+      row.dataset.setId = _id;
+      const a = document.createElement('a');
+      a.href = `../set/?_id=${_id}`;
+      a.textContent = setName;
+      row.insertCell(-1).appendChild(a);
+      row.insertCell(-1).textContent = difficulty;
+      row.insertCell(-1).textContent = standard;
+      row.insertCell(-1).textContent = '-';
+      row.insertCell(-1).textContent = '-';
+      row.insertCell(-1).textContent = '-';
+    });
   });
 
 fetch('/api/set-list?' + new URLSearchParams({ expand: true, includeCounts: true }))
   .then(res => res.json())
   .then(({ setList }) => {
     document.getElementById('spinner').classList.add('d-none');
-    const countsById = new Map(setList.map(set => [set._id, set]));
-    sets.forEach(set => {
-      const counts = countsById.get(set._id);
-      if (!counts) return;
-      set.packetsCount = counts.packetsCount;
-      set.tossupsCount = counts.tossupsCount;
-      set.bonusesCount = counts.bonusesCount;
-    });
-    if (['packetsCount', 'tossupsCount', 'bonusesCount'].includes(sortKey)) {
-      sets.sort((a, b) => compareRows(a, b, sortKey) * (sortAscending ? 1 : -1));
+    const table = document.getElementById('set-metadata-list');
+    // Look rows up by set id instead of index: the user may have sorted the
+    // table while this request was in flight, which reorders the rows.
+    const rowsBySetId = new Map(Array.from(table.rows).map(row => [row.dataset.setId, row]));
+    for (const { _id, packetsCount, tossupsCount, bonusesCount } of setList) {
+      const row = rowsBySetId.get(_id);
+      if (!row) { continue; }
+      row.cells[3].textContent = packetsCount;
+      row.cells[4].textContent = tossupsCount;
+      row.cells[5].textContent = bonusesCount;
     }
-    renderTable();
   });

--- a/client/scripts/utilities/tables.js
+++ b/client/scripts/utilities/tables.js
@@ -31,13 +31,13 @@ export default function sortTable (n, numeric = false, tableId = 'table', header
               based on the direction, asc or desc: */
       if (dir === 'asc') {
         if (numeric) {
-          if (parseFloat(x.innerHTML) < parseFloat(y.innerHTML)) {
+          if (parseFloat(x.textContent) < parseFloat(y.textContent)) {
             // If so, mark as a switch and break the loop:
             shouldSwitch = true;
             break;
           }
         } else {
-          if (x.innerHTML.toLowerCase() > y.innerHTML.toLowerCase()) {
+          if (x.textContent.toLowerCase() > y.textContent.toLowerCase()) {
             // If so, mark as a switch and break the loop:
             shouldSwitch = true;
             break;
@@ -45,13 +45,13 @@ export default function sortTable (n, numeric = false, tableId = 'table', header
         }
       } else if (dir === 'desc') {
         if (numeric) {
-          if (parseFloat(x.innerHTML) > parseFloat(y.innerHTML)) {
+          if (parseFloat(x.textContent) > parseFloat(y.textContent)) {
             // If so, mark as a switch and break the loop:
             shouldSwitch = true;
             break;
           }
         } else {
-          if (x.innerHTML.toLowerCase() < y.innerHTML.toLowerCase()) {
+          if (x.textContent.toLowerCase() < y.textContent.toLowerCase()) {
             // If so, mark as a switch and break the loop:
             shouldSwitch = true;
             break;

--- a/client/scripts/utilities/tables.js
+++ b/client/scripts/utilities/tables.js
@@ -1,78 +1,77 @@
+// Set names contain years and edition numbers, so compare them naturally
+// ("Set 9" before "Set 10") and case-insensitively.
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
 /**
  * Sorts a table by the values in a specified column.
+ *
+ * The first click on a column sorts it ascending; clicking the same column
+ * again reverses it. The active column and direction are recorded on the sorted
+ * element as `data-sort-column` and `data-sort-ascending`, so callers can render
+ * their own header indicators without tracking the state themselves.
+ *
+ * Cells with nothing to sort by - blank text, or text that isn't a number in a
+ * numeric column - always sort to the bottom, in both directions.
+ *
  * @param {number} n - a zero-indexed column number to sort
  * @param {boolean} numeric - whether the column values represent numeric values
- * @param {string} tableId - the id of the table to sort
+ * @param {string} tableId - the id of the table or table section to sort
  * @param {number} headers - the number of headers of the table to skip (default 1)
  * @param {number} footers - the number of footers of the table to skip (default 0)
  */
 export default function sortTable (n, numeric = false, tableId = 'table', headers = 1, footers = 0) {
-  let rows; let switching; let i; let x; let y; let shouldSwitch; let dir; let switchcount = 0;
   const table = document.getElementById(tableId);
-  switching = true;
-  // Set the sorting direction to ascending for text;
-  // Numerals are always sorted in the opposite order from text
-  dir = 'asc';
-  /* Make a loop that will continue until
-      no switching has been done: */
-  while (switching) {
-    // Start by saying: no switching is done:
-    switching = false;
-    rows = table.rows;
-    // Loop through all table rows (except headers and footers)
-    for (i = headers; i < rows.length - 1 - footers; i++) {
-      // Start by saying there should be no switching:
-      shouldSwitch = false;
-      /* Get the two elements you want to compare,
-        one from current row and one from the next: */
-      x = rows[i].children[n];
-      y = rows[i + 1].children[n];
-      /* Check if the two rows should switch place,
-              based on the direction, asc or desc: */
-      if (dir === 'asc') {
-        if (numeric) {
-          if (parseFloat(x.textContent) < parseFloat(y.textContent)) {
-            // If so, mark as a switch and break the loop:
-            shouldSwitch = true;
-            break;
-          }
-        } else {
-          if (x.textContent.toLowerCase() > y.textContent.toLowerCase()) {
-            // If so, mark as a switch and break the loop:
-            shouldSwitch = true;
-            break;
-          }
-        }
-      } else if (dir === 'desc') {
-        if (numeric) {
-          if (parseFloat(x.textContent) > parseFloat(y.textContent)) {
-            // If so, mark as a switch and break the loop:
-            shouldSwitch = true;
-            break;
-          }
-        } else {
-          if (x.textContent.toLowerCase() < y.textContent.toLowerCase()) {
-            // If so, mark as a switch and break the loop:
-            shouldSwitch = true;
-            break;
-          }
-        }
-      }
-    }
-    if (shouldSwitch) {
-      /* If a switch has been marked, make the switch
-              and mark that a switch has been done: */
-      rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
-      switching = true;
-      // Each time a switch is done, increase this count by 1:
-      switchcount++;
-    } else {
-      /* If no switching has been done AND the direction is "asc",
-              set the direction to "desc" and run the while loop again. */
-      if (switchcount === 0 && dir === 'asc') {
-        dir = 'desc';
-        switching = true;
-      }
-    }
-  }
+  if (table === null) { return; }
+
+  const rows = Array.from(table.rows);
+  const body = rows.slice(headers, rows.length - footers);
+  if (body.length < 2) { return; }
+
+  const ascending = !(table.dataset.sortColumn === String(n) && table.dataset.sortAscending === 'true');
+  const keyed = body.map(row => ({ row, key: sortKey(row.cells[n], numeric) }));
+  keyed.sort((a, b) => compareKeys(a.key, b.key, ascending));
+
+  // Moving the rows through a fragment detaches and reinserts each row once,
+  // instead of reflowing the table on every individual swap. Insert relative to
+  // the rows' own parent: when `tableId` names a <table>, its rows actually live
+  // in a <tbody>, so the table itself is the wrong node to insert into.
+  const parent = body[0].parentNode;
+  const footer = rows[rows.length - footers];
+  const fragment = document.createDocumentFragment();
+  for (const { row } of keyed) { fragment.appendChild(row); }
+  parent.insertBefore(fragment, footer && footer.parentNode === parent ? footer : null);
+
+  table.dataset.sortColumn = n;
+  table.dataset.sortAscending = ascending;
+}
+
+/**
+ * Reads the value a row should be sorted by.
+ * @param {HTMLTableCellElement} [cell] - the cell to read, if the row has one
+ * @param {boolean} numeric - whether the column values represent numeric values
+ * @returns {number | string | null} null if the cell has nothing to sort by
+ */
+function sortKey (cell, numeric) {
+  const text = cell ? cell.textContent.trim() : '';
+  if (text === '') { return null; }
+  if (!numeric) { return text; }
+  const value = parseFloat(text);
+  return isNaN(value) ? null : value;
+}
+
+/**
+ * @param {number | string | null} a
+ * @param {number | string | null} b
+ * @param {boolean} ascending
+ * @returns {number}
+ */
+function compareKeys (a, b, ascending) {
+  // Rows with nothing to sort by sink to the bottom either way, so that
+  // placeholders and blanks never interleave with real data.
+  if (a === null && b === null) { return 0; }
+  if (a === null) { return 1; }
+  if (b === null) { return -1; }
+
+  const order = typeof a === 'number' ? a - b : collator.compare(a, b);
+  return ascending ? order : -order;
 }


### PR DESCRIPTION
This pr is just an extension of #563 , i made a new one since there was a bunch of version control issues on 563. This fixes the `sortTable` algorithm at `\client\scripts\utilities\tables.js`.

## Fixes

- `parseFloat` returns NaN for any "-" placeholders that were added by `\client\db\set-list\index.js`. 
- Numeric columns used to sort ascending on the first click, while numbers were in descending order on the first click. They both now sort ascending first. 
- The directional toggle used to only work on columns that were already sorted. Since direction was inferred by re-reading the current DOM order, clicking a fresh column could not produce descending. The active column and direction are now recorded on the sorted element as `data-sort-column / data-sort-ascending`.

## Testing
- npm run lint &  npm run build run clean
- Set list sorting was all confirmed manually in Chrome

**Note**- /api/set-list?expand=true returns 50 sets instead of 711, which i believe is a bug introduced by #566 , I can investigate this further in a different pr if you would like. 